### PR TITLE
Add null reference protection

### DIFF
--- a/Assets/Scripts/DataController.cs
+++ b/Assets/Scripts/DataController.cs
@@ -344,10 +344,13 @@ public class DataController : MonoBehaviour
 
     public void ChangeStarSelection(GameObject selectedStar)
     {
-        StarComponent starComponent = selectedStar.GetComponent<StarComponent>();
-        starInfoPanel.GetComponent<StarInfoPanel>().UpdateStarInfoPanel(starComponent.starData.XByerFlamsteed,
-                                                                        starComponent.starData.Mag.ToString(),
-                                                                        starComponent.starData.Constellation);
-        starInfoPanel.GetComponent<WorldToScreenPos>().UpdatePosition(selectedStar);
+        if (starInfoPanel)
+        {
+            StarComponent starComponent = selectedStar.GetComponent<StarComponent>();
+            starInfoPanel.GetComponent<StarInfoPanel>().UpdateStarInfoPanel(starComponent.starData.XByerFlamsteed,
+                                                                            starComponent.starData.Mag.ToString(),
+                                                                            starComponent.starData.Constellation);
+            starInfoPanel.GetComponent<WorldToScreenPos>().UpdatePosition(selectedStar);
+        }
     }
 }

--- a/Assets/Scripts/StarComponent.cs
+++ b/Assets/Scripts/StarComponent.cs
@@ -40,23 +40,26 @@ public class StarComponent : MonoBehaviour
 
     void OnMouseDown()
     {
-        if (dataController)
+        if (dataController && dataController.starInfoPanel)
         {
             dataController.ChangeConstellationHighlight(starData.Constellation);
         }
     }
     void OnMouseOver()
     {
-        if (dataController)
+        if (dataController && dataController.starInfoPanel)
         {
             dataController.ChangeStarSelection(this.gameObject);
+            pulse = true;
         }
-        pulse = true;
     }
 
     void OnMouseExit()
     {
-        pulse = false;
-        transform.localScale = initialScale;
+        if (dataController && dataController.starInfoPanel)
+        {
+            pulse = false;
+            transform.localScale = initialScale;
+        }
     }
 }


### PR DESCRIPTION
Ahead of any refactoring, this will eliminate any null references tied to mouse events and star objects.  Scenes are designed to behave differently depending on whether or not certain game objects are present.  Changes add extra checks to ensure that we bypass functionality unless required game objects are present.