### PR TITLE
Improve star rendering

### DIFF
--- a/Assets/Prefabs/Star.prefab
+++ b/Assets/Prefabs/Star.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 5714522309841809801}
   m_Layer: 12
   m_Name: Star
-  m_TagString: Untagged
+  m_TagString: Star
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scripts/DataController.cs
+++ b/Assets/Scripts/DataController.cs
@@ -145,7 +145,7 @@ public class DataController : MonoBehaviour
                     // color by constellation
                     if (colorByConstellation == true)
                     {
-                        Utils.GetInstance().SetObjectColor(starObject, constellationColor);
+                        Utils.SetObjectColor(starObject, constellationColor);
                     }
 
                     allStarComponents[starCount] = newStar;
@@ -190,7 +190,7 @@ public class DataController : MonoBehaviour
         newMarker.label.text = markerName;
         newMarker.markerData = marker;
         markerObject.name = markerName;
-        Utils.GetInstance().SetObjectColor(markerObject, color);
+        Utils.SetObjectColor(markerObject, color);
 
         if (showHorizonView)
         {
@@ -316,12 +316,12 @@ public class DataController : MonoBehaviour
             {
                 Color constellationColor = starObject.GetComponent<StarComponent>().constellationColor;
 
-                Utils.GetInstance().SetObjectColor(starObject, constellationColor);
+                Utils.SetObjectColor(starObject, constellationColor);
             }
             else
             {
                 Color starColor = starObject.GetComponent<StarComponent>().starColor;
-                Utils.GetInstance().SetObjectColor(starObject, starColor);
+                Utils.SetObjectColor(starObject, starColor);
             }
         }
         constellationDropdown.GetComponent<ConstellationDropdown>().UpdateConstellationSelection(highlightConstellation);

--- a/Assets/Scripts/StarComponent.cs
+++ b/Assets/Scripts/StarComponent.cs
@@ -1,10 +1,11 @@
-﻿ using UnityEngine;
- using UnityEngine.EventSystems;
+﻿using UnityEngine;
+using UnityEngine.EventSystems;
 
 public class StarComponent : MonoBehaviour
 {
     public Star starData;
     public Color starColor;
+    public Color constellationColor;
 
     private GameObject dataControllerObj;
     private DataController dataController;
@@ -62,5 +63,14 @@ public class StarComponent : MonoBehaviour
             pulse = false;
             transform.localScale = initialScale;
         }
+    }
+
+    public void SetStarColor(Color constellationColor, Color starColor)
+    {
+        // Store star color - not yet using real values
+        this.starColor = starColor;
+        // Store constellation color
+        this.constellationColor = constellationColor;
+
     }
 }

--- a/Assets/Scripts/Utils.cs
+++ b/Assets/Scripts/Utils.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using UnityEngine;
+public class Utils
+{
+    protected Utils()
+    {
+    }
+    private static Utils instance;
+    public static Utils GetInstance()
+    {
+        return instance ?? (instance = new Utils());
+    }
+
+    public void SetObjectColor(GameObject go, Color newColor)
+    {
+        Mesh mesh = go.GetComponent<MeshFilter>().mesh;
+        if (mesh)
+        {
+            Vector3[] vertices = mesh.vertices;
+
+            // create new colors array where the colors will be created.
+            Color[] colors = new Color[vertices.Length];
+
+            for (int i = 0; i < vertices.Length; i++)
+                colors[i] = newColor;
+
+            // assign the array of colors to the Mesh.
+            mesh.colors = colors;
+        }
+    }
+}

--- a/Assets/Scripts/Utils.cs
+++ b/Assets/Scripts/Utils.cs
@@ -1,17 +1,8 @@
 ﻿using System;
 using UnityEngine;
-public class Utils
+public static class Utils
 {
-    protected Utils()
-    {
-    }
-    private static Utils instance;
-    public static Utils GetInstance()
-    {
-        return instance ?? (instance = new Utils());
-    }
-
-    public void SetObjectColor(GameObject go, Color newColor)
+    public static void SetObjectColor(GameObject go, Color newColor)
     {
         Mesh mesh = go.GetComponent<MeshFilter>().mesh;
         if (mesh)

--- a/Assets/Scripts/Utils.cs.meta
+++ b/Assets/Scripts/Utils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cda8b00295f7a488f86573dd089cca98
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This small PR improves star rendering by using mesh vertex colors instead of changing material colors. Changing material colors creates individual instances of materials, which is very wasteful for our purposes. This technique saves over 500 draw calls since all stars now share a material.

Pre-tagged Star objects - we have a prefab for Stars, so easy to tag it before we add it to save some time.

Also added a new static Utils class with simple method to change object colors. 