### PR TITLE
Add protection around scene change and date/time updates in main UI

### DIFF
--- a/Assets/Scripts/MainUIController.cs
+++ b/Assets/Scripts/MainUIController.cs
@@ -106,7 +106,7 @@ public class MainUIController : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (currentDateTimeText)
+        if (currentDateTimeText && dataController)
         {
             currentDateTimeText.text = dataController.CurrentSimUniversalTime().ToString() + " (UTC)";
         }

--- a/Assets/Scripts/SceneController.cs
+++ b/Assets/Scripts/SceneController.cs
@@ -5,16 +5,18 @@ using UnityEngine.SceneManagement;
 
 public class SceneController : MonoBehaviour
 {
+    int firstSceneIndex = 0;
     // Start is called before the first frame update
     void Start()
     {
-
+        string sceneName = System.IO.Path.GetFileNameWithoutExtension(SceneUtility.GetScenePathByBuildIndex(0));
+        if (sceneName == "LoadSim") firstSceneIndex = 1;
     }
 
     public void LoadPreviousScene ()
     {
         Debug.Log("LoadPreviousScene");
-        if (SceneManager.GetActiveScene().buildIndex <= 1)
+        if (SceneManager.GetActiveScene().buildIndex <= firstSceneIndex)
         {
             SceneManager.LoadScene(SceneManager.sceneCountInBuildSettings - 1);
         }
@@ -29,7 +31,7 @@ public class SceneController : MonoBehaviour
         Debug.Log("LoadNextScene");
         if (SceneManager.GetActiveScene().buildIndex + 1 >= SceneManager.sceneCountInBuildSettings)
         {
-            SceneManager.LoadScene(1);
+            SceneManager.LoadScene(firstSceneIndex);
         }
         else
         {


### PR DESCRIPTION
A few small changes based on updates to the Vuforia fork.  These are all good protections to have in the main project to avoid future errors or exceptions.
- add protection around dataController in MainUIController in case object is null
- only skip 0th scene when user changes to prev/next scene if 0th scene is the LoadSim loading scene