### PR TITLE
Reorient celestial sphere. Sync times.

### DIFF
--- a/Assets/Scripts/Core/CelestialSphereItem.cs
+++ b/Assets/Scripts/Core/CelestialSphereItem.cs
@@ -33,10 +33,4 @@ public abstract class CelestialSphereItem
     {
         return Utils.CalculateEquitorialPosition(radianRA, radianDec, radius);
     }
-
-    // calculate the position of stars at a point on Earth
-    public Vector3 CalculateHorizonPosition(float radius, double currentSiderialTime, float observerLatitude)
-    {
-        return Utils.CalculateHorizonPosition(RA, radianDec, radius, currentSiderialTime, observerLatitude);
-    }
 }

--- a/Assets/Scripts/DataController.cs
+++ b/Assets/Scripts/DataController.cs
@@ -311,10 +311,9 @@ public class DataController : MonoBehaviour
                     float fractionOfDay = (float)lst / siderealHoursPerDay;
                     float planetRotation = fractionOfDay * 360;
                     
-                    // TODO: switch from reset & recalculate to just setting the angle around the existing axis
+                    // Start from initial rotation then rotate around for the current time and offset
                     transform.rotation = initialRotation;
-                    transform.Rotate(0, celestialSphereOffsetR, 0, Space.Self);
-                    transform.Rotate(0, planetRotation, 0, Space.Self);
+                    transform.Rotate(0, (celestialSphereOffsetR + planetRotation), 0, Space.Self);
                     // Set last timestamp so we only update when changed
                     lastTime = lst;
                 }

--- a/Assets/Scripts/DataController.cs
+++ b/Assets/Scripts/DataController.cs
@@ -298,7 +298,7 @@ public class DataController : MonoBehaviour
                 }
                 else
                 {
-                    lst = DateTime.Now.ToSiderealTime();
+                    lst = DateTime.UtcNow.ToSiderealTime();
                 }
 
                 // Filter and only update positions if changed time / latitude
@@ -306,11 +306,15 @@ public class DataController : MonoBehaviour
 
                 if (shouldUpdate)
                 {
-                    float fractionOfDay = ((float)lst / 24) * 360;
+                    float celestialSphereOffsetR = -45f; 
+                    float siderealHoursPerDay = 23.9344696f;
+                    float fractionOfDay = (float)lst / siderealHoursPerDay;
+                    float planetRotation = fractionOfDay * 360;
+                    
                     // TODO: switch from reset & recalculate to just setting the angle around the existing axis
                     transform.rotation = initialRotation;
-                    // axis is offset by 90 degrees
-                    transform.Rotate(0, fractionOfDay + 90, 0, Space.Self);
+                    transform.Rotate(0, celestialSphereOffsetR, 0, Space.Self);
+                    transform.Rotate(0, planetRotation, 0, Space.Self);
                     // Set last timestamp so we only update when changed
                     lastTime = lst;
                 }

--- a/Assets/Scripts/Utilities/Utils.cs
+++ b/Assets/Scripts/Utilities/Utils.cs
@@ -56,6 +56,7 @@ public static class Utils
         return new Vector3(xPos, yPos, zPos);
     }
 
+    [Obsolete]
     public static Vector3 CalculateHorizonPosition(float RA, float radianDec, float radius, double currentSiderialTime, float observerLatitude)
     {
         float Alt = 0;
@@ -91,8 +92,9 @@ public static class Utils
 
     public static Vector3 CalculatePositionByAzAlt(float azimuth, float altitude, float radius)
     {
-        var zPos = radius * (Mathf.Cos(azimuth)) * (Mathf.Cos(altitude)); // ; RA in hours, so multiply RA by 15 deg / hr
-        var xPos = radius * (Mathf.Cos(altitude) * (Mathf.Sin(azimuth)));
+        // our ground uses Z for North, so we need to flip this around a little
+        var zPos = radius * (Mathf.Cos(azimuth)) * (Mathf.Cos(altitude)) * -1; 
+        var xPos = radius * (Mathf.Cos(altitude) * (Mathf.Sin(azimuth))) * -1;
         var yPos = radius * Mathf.Sin(altitude);
 
         if (float.IsNaN(xPos))


### PR DESCRIPTION
* Manually set time and automatic time star positions are in accordance, now both use `UtcNow`
* The Celestial Sphere had to be rotated 45 degrees.
* Rotational fraction of the planet is not quite 24 siderealHours hours. I am not sure if that is significant or not.

[#166009320]
https://www.pivotaltracker.com/story/show/166009320