### PR TITLE
Click user label to visit pin

### DIFF
--- a/Assets/Scripts/SimulationManager.cs
+++ b/Assets/Scripts/SimulationManager.cs
@@ -21,22 +21,17 @@ public class SimulationManager
     // A decent random generator
     public System.Random rng = new System.Random();
 
-    // List of scenes in project for current build target
-    private readonly string[] _desktopScenes = new string[4] { "LoadSim", "Stars", "Horizon", "EarthInteraction" };
-    private readonly string[] _ARScenes = new string[4] { "LoadSim", "Stars", "Horizon", "EarthInteraction" };
-    private readonly string[] _VRScenes = new string[4] { "LoadSim", "Stars", "Horizon", "EarthInteraction" };
-
     public string[] Scenes {
         get {
 #if UNITY_STANDALONE
-            return this._desktopScenes;
+            return SimulationConstants.SCENES_PC;
 #elif UNITY_IOS
-            return this._ARScenes;
+            return SimulationConstants.SCENES_AR;
 #elif UNITY_ANDROID
-            return this._VRScenes;
+            return SimulationConstants.SCENES_VR;
 #else
             // Catch-all default
-            return this._desktopScenes;
+            return SimulationConstants.SCENES_PC;
 #endif
         }
     }

--- a/Assets/Scripts/Utilities/SimulationConstants.cs
+++ b/Assets/Scripts/Utilities/SimulationConstants.cs
@@ -12,4 +12,14 @@ public static class SimulationConstants
     public static readonly string SNAPSHOT_DATETIME_PREF_KEY = "SnapshotDateTime";
     public static readonly string SNAPSHOT_LOCATION_COORDS_PREF_KEY = "SnapshotLocationCoords";
 
+    // Scene Names:
+    public static readonly string SCENE_LOAD = "LoadSim";
+    public static readonly string SCENE_STARS = "Stars";
+    public static readonly string SCENE_HORIZON = "Horizon";
+    public static readonly string SCENE_EARTH = "EarthInteraction";
+
+    // Platform Scene Listings:
+    public static readonly string[] SCENES_VR = { SCENE_LOAD, SCENE_STARS, SCENE_HORIZON, SCENE_EARTH };
+    public static readonly string[] SCENES_AR = { SCENE_LOAD, SCENE_STARS, SCENE_HORIZON, SCENE_EARTH };
+    public static readonly string[] SCENES_PC = { SCENE_LOAD, SCENE_STARS, SCENE_HORIZON, SCENE_EARTH };
 }


### PR DESCRIPTION
So this *almost* works see `PlayerLabelClicked` for the substance of it.

Seems like sometimes clicking on the label doesn't behave as it should.  It will load up the wrong location (The Location UI is incorrect).

I looked at the DataController, and noticed that is was setting nextLocation instead of location.  It seemed like I could trigger that with `PushPinSelected.Invoke(pin.Location, pin.SelectedDateTime)` but apparently not? 