### PR TITLE
Color lines by user color when selecting a constellation

### DIFF
--- a/Assets/Scripts/Constellation.cs
+++ b/Assets/Scripts/Constellation.cs
@@ -27,6 +27,14 @@ public class Constellation : MonoBehaviour
         constellationConnections.Add(conn);
     }
 
+    public void Highlight(bool highlight, Color userHighlightColor)
+    {
+        // foreach (GameObject starObject in stars)
+        foreach (GameObject connectionObject in constellationLines)
+        {
+            Utils.SetObjectColor(connectionObject, highlight ? userHighlightColor : neutralColor);
+        }
+    }
     public void Highlight(bool highlight)
     {
         foreach (GameObject starObject in stars)

--- a/Assets/Scripts/ConstellationsController.cs
+++ b/Assets/Scripts/ConstellationsController.cs
@@ -52,6 +52,14 @@ public class ConstellationsController : MonoBehaviour
             constellation.ShowConstellationLines(constellation.constellationNameFull == cFullName, lineWidth);
         }
     }
+    public void HighlightSingleConstellation(string cFullName, Color playerColor)
+    {
+        foreach (Constellation constellation in constellations)
+        {
+            constellation.Highlight(constellation.constellationNameFull == cFullName, playerColor);
+            constellation.ShowConstellationLines(constellation.constellationNameFull == cFullName, lineWidth);
+        }
+    }
 
     public void HighlightAllConstellations(bool highlight)
     {

--- a/Assets/Scripts/InteractionController.cs
+++ b/Assets/Scripts/InteractionController.cs
@@ -122,7 +122,7 @@ public class InteractionController : MonoBehaviour
                 // TODO: Adjust how we create stars to make it possible to find the star from the network interaction
                 // this could be a simple rename, but need to check how constellation grouping works. Ideally we'll
                 // maintain a dict of stars by ID for easier lookups. 
-                manager.DataControllerComponent.GetStarById(updatedPlayer.celestialObjectTarget.uniqueId).HandleSelectStar();
+                manager.DataControllerComponent.GetStarById(updatedPlayer.celestialObjectTarget.uniqueId).HandleSelectStar(false, UserRecord.GetColorForUsername(updatedPlayer.username));
                 break;
             case "locationpin":
                 // add / move player pin

--- a/Assets/Scripts/MainUIController.cs
+++ b/Assets/Scripts/MainUIController.cs
@@ -287,6 +287,11 @@ public class MainUIController : MonoBehaviour
             buttonToDisable.GetComponent<Button>().enabled = false;
             buttonToDisable.GetComponent<Image>().color = Color.gray;
         }
+        if (!snapshotsController)
+        {
+            snapshotsController = FindObjectOfType<SnapshotsController>();
+            if (snapshotsController != null) snapshotsController.Init();
+        }
     }
 
     // Update is called once per frame
@@ -637,6 +642,11 @@ public class MainUIController : MonoBehaviour
 
     public void RestoreSnapshot(Snapshot snapshot)
     {
+        if (!snapshotsController)
+        {
+            snapshotsController = FindObjectOfType<SnapshotsController>();
+            snapshotsController.Init();
+        }
         int snapshotIndex = snapshotsController.snapshots.FindIndex(el => el.location == snapshot.location && el.dateTime == snapshot.dateTime);
         // user restores snapshot from UI
         Snapshot snap = snapshotsController.snapshots[snapshotIndex];

--- a/Assets/Scripts/SimulationManager.cs
+++ b/Assets/Scripts/SimulationManager.cs
@@ -35,7 +35,8 @@ public class SimulationManager
 #endif
         }
     }
-    public GameObject NetworkControllerObject;
+
+    public NetworkController NetworkControllerComponent;
     public GameObject InteractionControllerObject;
     public ServerRecord server = null;
     private GameObject celestialSphereObject;

--- a/Assets/Scripts/SimulationManagerComponent.cs
+++ b/Assets/Scripts/SimulationManagerComponent.cs
@@ -103,16 +103,16 @@ public class SimulationManagerComponent : MonoBehaviour
             sceneLoader = Instantiate(sceneLoaderPrefab);
         }
         
-        if (manager.NetworkControllerObject == null)
+        if (manager.NetworkControllerComponent == null)
         {
             if (FindObjectOfType<NetworkController>() != null)
             {
-                manager.NetworkControllerObject = FindObjectOfType<NetworkController>().gameObject;
+                manager.NetworkControllerComponent = FindObjectOfType<NetworkController>();
             }
             else
             {
                 Debug.Log("Creating new network object");
-                manager.NetworkControllerObject = Instantiate(networkControllerPrefab);
+                manager.NetworkControllerComponent = Instantiate(networkControllerPrefab).GetComponent<NetworkController>();
             }
         }
         if (manager.InteractionControllerObject == null)
@@ -177,7 +177,7 @@ public class SimulationManagerComponent : MonoBehaviour
         if (!mainUIController) 
         {
             mainUIController = Instantiate(mainUIPrefab).GetComponent<MainUIController>();
-            manager.NetworkControllerObject.GetComponent<NetworkController>().Setup();
+            manager.NetworkControllerComponent.Setup();
         } 
         sceneLoader.SetupCameras();
         

--- a/Assets/Scripts/SnapshotsController.cs
+++ b/Assets/Scripts/SnapshotsController.cs
@@ -6,7 +6,7 @@ using System;
 public class SnapshotsController : MonoBehaviour
 {
     public List<Snapshot> snapshots = new List<Snapshot>();
-
+    
     string locationKey
     {
         get { return SimulationConstants.SNAPSHOT_LOCATION_PREF_KEY; }

--- a/Assets/Scripts/StarComponent.cs
+++ b/Assets/Scripts/StarComponent.cs
@@ -34,6 +34,18 @@ public class StarComponent : MonoBehaviour, IPointerDownHandler, IPointerExitHan
 
     public void HandleSelectStar(bool broadcastToNetwork = false)
     {
+        SimulationManager manager = SimulationManager.GetInstance();
+        if (manager.NetworkControllerComponent.IsConnected)
+        {
+            HandleSelectStar(broadcastToNetwork, manager.LocalPlayerColor);
+        }
+        else
+        {
+            HandleSelectStar(broadcastToNetwork, Color.white);
+        }
+    }
+    public void HandleSelectStar(bool broadcastToNetwork, Color playerColor)
+    {
         if (!mainUIController) mainUIController = FindObjectOfType<MainUIController>();
         if (!mainUIController.IsDrawing)
         {
@@ -43,7 +55,10 @@ public class StarComponent : MonoBehaviour, IPointerDownHandler, IPointerExitHan
             if (mainUIController && mainUIController.starInfoPanel)
             {
                 if (constellationsController)
-                    constellationsController.HighlightSingleConstellation(starData.ConstellationFullName);
+                {
+                    constellationsController.HighlightSingleConstellation(starData.ConstellationFullName, playerColor);
+                }
+
                 // make sure it's visible
                 SimulationManager.GetInstance().CurrentlySelectedStar = this;
                 mainUIController.ShowPanel("StarInfoPanel");


### PR DESCRIPTION
Only show lines for single constellation selection in player color when a player is connected to the network - this is to differentiate between "who clicked that?".