### PR TITLE
Fix snapshot add overwriting other snap items in grid

### DIFF
--- a/Assets/Prefabs/MainUI.prefab
+++ b/Assets/Prefabs/MainUI.prefab
@@ -5500,7 +5500,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2724144227609589291}
   m_HandleRect: {fileID: 2724144227609589290}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -12313,7 +12313,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2724144226661976861}
   m_HandleRect: {fileID: 2724144226661976860}
   m_Direction: 0
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:

--- a/Assets/Prefabs/SnapItem.prefab
+++ b/Assets/Prefabs/SnapItem.prefab
@@ -118,18 +118,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 8057081476642263005}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 5418610634536918532}
-        m_MethodName: RestoreSnapItem
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
 --- !u!1 &1490539486478078359
 GameObject:
   m_ObjectHideFlags: 0
@@ -394,18 +383,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 5941151350831557220}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 5418610634536918532}
-        m_MethodName: DeleteSnapItem
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
 --- !u!1 &5418610634536918531
 GameObject:
   m_ObjectHideFlags: 0
@@ -458,6 +436,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   snapItemText: {fileID: 4957073979454038305}
+  snapshot:
+    Location:
+      Latitude: 0
+      Longitude: 0
+    LocationName: (Custom Location)
+    ReadableDate: 
+  pinButton: {fileID: 437598397889661078}
+  deleteButton: {fileID: 5333648673805919997}
 --- !u!1 &5537977810418638052
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Core/Pushpin.cs
+++ b/Assets/Scripts/Core/Pushpin.cs
@@ -1,11 +1,13 @@
 using System;
 using UnityEngine;
 
+[Serializable]
 public class Pushpin
 {
     public LatLng Location;
     public DateTime SelectedDateTime;
     public string LocationName;
+    [SerializeField] private string ReadableDate;
     
     public override string ToString()
     {
@@ -14,14 +16,37 @@ public class Pushpin
 
     public Pushpin()
     {
-        SelectedDateTime = DateTime.UtcNow;
+        this.SelectedDateTime = DateTime.UtcNow;
+        this.Location = new LatLng();
+        this.LocationName = SimulationConstants.CUSTOM_LOCATION;
     }
 
     public Pushpin(DateTime dt, LatLng latLng, string locationName)
     {
-        SelectedDateTime = dt;
-        Location = latLng;
-        LocationName = String.IsNullOrEmpty(locationName) ? SimulationConstants.CUSTOM_LOCATION : locationName;
+        this.SelectedDateTime = dt;
+        this.Location = latLng;
+        this.LocationName = String.IsNullOrEmpty(locationName) ? SimulationConstants.CUSTOM_LOCATION : locationName;
+        this.ReadableDate = SelectedDateTime.ToString();
+    }
+    
+    public override bool Equals(System.Object obj)
+    {
+        //Check for null and compare run-time types.
+        if ((obj == null) || ! this.GetType().Equals(obj.GetType())) 
+        {
+            return false;
+        }
+        else { 
+            Pushpin p = (Pushpin) obj; 
+            return (Location == p.Location) && (SelectedDateTime == p.SelectedDateTime);
+        }   
+    }
+
+    public override int GetHashCode()
+    { 
+        int t = this.SelectedDateTime.Hour + this.SelectedDateTime.Minute + this.SelectedDateTime.Second;
+        int ll = (int)this.Location.Latitude + (int)this.Location.Longitude;
+        return (t + ll);
     }
 }
 

--- a/Assets/Scripts/MainUIController.cs
+++ b/Assets/Scripts/MainUIController.cs
@@ -296,7 +296,7 @@ public class MainUIController : MonoBehaviour
     {
         if (currentDateTimeText && dataController)
         {
-            currentDateTimeText.text = manager.CurrentSimulationTime.ToString() + " (UTC)";
+            currentDateTimeText.text = manager.CurrentSimulationTime.ToString("MMMM dd yyyy HH:mm:ss") + " (UTC)";
         }
 
         // allow change of time in all scenes - should work in Earth scene to switch seasons

--- a/Assets/Scripts/MainUIController.cs
+++ b/Assets/Scripts/MainUIController.cs
@@ -609,12 +609,15 @@ public class MainUIController : MonoBehaviour
 
     public void CreateSnapshot()
     {
+        // Update local player pin to remote players - unsure if this is needed
+        calculateUserDateTime(true);
         // get values from simulation manager
-        manager.LocalUserSnapshots.Add(manager.LocalUserPin);
+        Pushpin newPin = new Pushpin(manager.CurrentSimulationTime, manager.CurrentLatLng, manager.CurrentLocationName);
+        manager.LocalUserSnapshots.Add(newPin);
         // add a snapshot to the controller
-        snapshotsController.SaveSnapshot(manager.LocalUserPin, manager.LocalUserSnapshots.Count - 1);
+        snapshotsController.SaveSnapshot(newPin, manager.LocalUserSnapshots.Count - 1);
         // add snapshot to dropdown list
-        AddSnapshotToGrid(manager.LocalUserPin);
+        AddSnapshotToGrid(newPin);
     }
 
     public void AddSnapshotToGrid(Pushpin snapshot)
@@ -660,10 +663,10 @@ public class MainUIController : MonoBehaviour
     }
     public void DeleteSnapshot(Pushpin deleteSnap)
     {
-        int snapshotIndex = manager.LocalUserSnapshots.FindIndex(el => el.Location == deleteSnap.Location && el.SelectedDateTime == deleteSnap.SelectedDateTime);
-        manager.LocalUserSnapshots.RemoveAt(snapshotIndex);
-
-        snapshotsController.DeleteSnapshot(deleteSnap);
+        Pushpin match = manager.LocalUserSnapshots.Find(p => p.Equals(deleteSnap));
+        Debug.Log($"Deleting snapshot: {match}");
+        manager.LocalUserSnapshots.Remove(match);
+        snapshotsController.DeleteSnapshot(match);
     }
 
     private void updateOnPinSelected(Pushpin pin)

--- a/Assets/Scripts/SnapshotsController.cs
+++ b/Assets/Scripts/SnapshotsController.cs
@@ -55,9 +55,9 @@ public class SnapshotsController : MonoBehaviour
 
     public void SaveSnapshot(Pushpin pin, int pinIndex)
     {
-        PlayerPrefs.SetString(locationKey + pinIndex.ToString(), pin.LocationName);
-        PlayerPrefs.SetString(datetimeKey + pinIndex.ToString().ToString(), pin.SelectedDateTime.ToString());
-        PlayerPrefs.SetString(coordsKey + pinIndex.ToString().ToString(), pin.Location.ToString());
+        PlayerPrefs.SetString(locationKey + pinIndex, pin.LocationName);
+        PlayerPrefs.SetString(datetimeKey + pinIndex, pin.SelectedDateTime.ToString());
+        PlayerPrefs.SetString(coordsKey + pinIndex, pin.Location.ToString());
     }
 
     public void DeleteSnapshot(Pushpin snapshot)

--- a/Assets/Scripts/UI/SnapGrid.cs
+++ b/Assets/Scripts/UI/SnapGrid.cs
@@ -19,7 +19,7 @@ public class SnapGrid : MonoBehaviour
     public void AddSnapItem(Pushpin newSnap)
     {
         if (snaps == null) snaps = new List<GameObject>();
-        string snapText = newSnap.LocationName + ":\n" + newSnap.SelectedDateTime.ToShortDateString() + " " + newSnap.SelectedDateTime.ToShortTimeString();
+        string snapText = newSnap.LocationName + ":\n" + newSnap.SelectedDateTime.ToShortDateString() + " " + newSnap.SelectedDateTime.ToString("HH:mm:ss");
         GameObject snapItem = Instantiate(snapItemPrefab, transform);
         snapItem.GetComponent<SnapItem>().snapItemText.text = snapText;
         snapItem.GetComponent<SnapItem>().SetSnapPin(newSnap);

--- a/Assets/Scripts/UI/SnapGrid.cs
+++ b/Assets/Scripts/UI/SnapGrid.cs
@@ -20,9 +20,9 @@ public class SnapGrid : MonoBehaviour
     {
         if (snaps == null) snaps = new List<GameObject>();
         string snapText = newSnap.LocationName + ":\n" + newSnap.SelectedDateTime.ToShortDateString() + " " + newSnap.SelectedDateTime.ToShortTimeString();
-        GameObject snapItem = (GameObject)Instantiate(snapItemPrefab, transform);
+        GameObject snapItem = Instantiate(snapItemPrefab, transform);
         snapItem.GetComponent<SnapItem>().snapItemText.text = snapText;
-        snapItem.GetComponent<SnapItem>().snapshot = newSnap;
+        snapItem.GetComponent<SnapItem>().SetSnapPin(newSnap);
         snaps.Add(snapItem);
     }
 }

--- a/Assets/Scripts/UI/SnapItem.cs
+++ b/Assets/Scripts/UI/SnapItem.cs
@@ -2,27 +2,42 @@
 using System.Collections.Generic;
 using UnityEngine;
 using TMPro;
+using UnityEngine.UI;
 
 public class SnapItem : MonoBehaviour
 {
     public TextMeshProUGUI snapItemText;
-    public Pushpin snapshot;
+    [SerializeField]
+    private Pushpin snapshot;
+
+    public GameObject pinButton;
+    public GameObject deleteButton;
 
     private MainUIController mainUIController;
 
     void Start()
     {
         mainUIController = FindObjectOfType<MainUIController>();
+        Button pb = pinButton.GetComponent<Button>();
+        pb.onClick.AddListener( () => RestoreSnapItem());
+        Button db = deleteButton.GetComponent<Button>();
+        db.onClick.AddListener(() => DeleteSnapItem());
     }
 
+    public void SetSnapPin(Pushpin pin)
+    {
+        snapshot = new Pushpin(pin.SelectedDateTime, pin.Location, pin.LocationName);
+    }
     public void DeleteSnapItem()
     {
-        mainUIController.DeleteSnapshot(snapshot);
-        Destroy(gameObject);
+        mainUIController.DeleteSnapshot(this.snapshot);
+        Destroy(this.gameObject);
     }
 
     public void RestoreSnapItem()
     {
-        mainUIController.RestoreSnapshot(snapshot);
+        Debug.Log($"Restoring my snapshot {this.snapshot}");
+        Pushpin p = new Pushpin(this.snapshot.SelectedDateTime, this.snapshot.Location, this.snapshot.LocationName);
+        mainUIController.RestoreSnapshot(p);
     }
 }

--- a/Assets/Scripts/Utilities/CCLogger.cs
+++ b/Assets/Scripts/Utilities/CCLogger.cs
@@ -270,7 +270,7 @@ public class CCLogger
         string json = JsonUtility.ToJson(this, true);
 
         #if UNITY_EDITOR
-            Debug.Log(json);
+            // Debug.Log(json);
         #endif
 
         // Only send to log manager if we're on the network to reduce clutter

--- a/Assets/Scripts/Utilities/TimeConverter.cs
+++ b/Assets/Scripts/Utilities/TimeConverter.cs
@@ -164,16 +164,16 @@ public static class TimeConverter
         return t0;
     }
 
-    private static readonly DateTime epoch = new DateTime(1970, 1, 1, 0, 0, 0);
+    public static readonly DateTime EpochDate = new DateTime(1970, 1, 1, 0, 0, 0);
     public static double ToEpochTime(this DateTime date)
     {
-        TimeSpan timeSpan = date - epoch;
+        TimeSpan timeSpan = date - EpochDate;
 
         return timeSpan.TotalSeconds;
     }
-
+    
     public static DateTime EpochTimeToDate(double unixDate)
     {
-        return epoch.AddSeconds(unixDate);
+        return EpochDate.AddSeconds(unixDate);
     }
 }

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -38,6 +38,7 @@ GraphicsSettings:
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16002, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
Seems there's some object reference stickiness going on, so creating new pins to update the world seems to have fixed the issue for now. I had a lot of trouble removing items from the grid layout, so I wonder if similar issues persist in the network UI (hence our players leaving traces when they have disconnected). 