### PR TITLE
Fix websocket handling of undefined and null values

### DIFF
--- a/Assets/Plugins/WebSocket/WebSocket.jslib
+++ b/Assets/Plugins/WebSocket/WebSocket.jslib
@@ -165,7 +165,7 @@ var LibraryWebSocket = {
 		if (!instance) return 0;
 
 		// Close if not closed
-		if (instance.ws !== null && instance.ws.readyState < 2)
+		if (instance.ws && instance.ws.readyState < 2)
 			instance.ws.close();
 
 		// Remove reference
@@ -289,7 +289,7 @@ var LibraryWebSocket = {
 		var instance = webSocketState.instances[instanceId];
 		if (!instance) return -1;
 
-		if (instance.ws === null)
+		if (!instance.ws)
 			return -3;
 
 		if (instance.ws.readyState === 2)
@@ -322,7 +322,7 @@ var LibraryWebSocket = {
 		var instance = webSocketState.instances[instanceId];
 		if (!instance) return -1;
 
-		if (instance.ws === null)
+		if (!instance.ws)
 			return -3;
 
 		if (instance.ws.readyState !== 1)
@@ -346,7 +346,7 @@ var LibraryWebSocket = {
 		var instance = webSocketState.instances[instanceId];
 		if (!instance) return -1;
 
-		if (instance.ws === null)
+		if (!instance.ws)
 			return -3;
 
 		if (instance.ws.readyState !== 1)


### PR DESCRIPTION
This PR fixes an issue in the Colyseus Javascript code that was checking against null and not undefined.  This caused an exception in the WebGL build when the user changed to another tab and then returned to CEASAR.