### PR TITLE
Add pre-styled index.html file to use during build process and update readme

### DIFF
--- a/Assets/HTML.meta
+++ b/Assets/HTML.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8bc1826f3007bfc418fc01e2de141c1c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HTML/index.html
+++ b/Assets/HTML/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>CEASAR</title>
+    <script src="Build/UnityLoader.js"></script>
+    <script>
+      UnityLoader.instantiate("unityContainer", "Build/CEASAR.json");
+    </script>
+  </head>
+  <body style="width: calc(100vw - 16px); height: calc(100vh - 16px)">
+    <div id="unityContainer" style="width: 100%; height: 100%; margin: auto"></div>
+  </body>
+</html>

--- a/Assets/HTML/index.html.meta
+++ b/Assets/HTML/index.html.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1c56cbb99d6015e44b72be686d7cf088
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ As of July 2021 Unity Cloud Builds are no longer running. Previously Cloud Build
 To build for `WebGL`:
 * in the Unity editor, change the build target to `WebGL`
 * Rename the `Oculus` folder to `Oculus~` to hide the folder from Unity
-* Do the build to WebGL
+* Create the WebGL build in a folder named `CEASAR`
 * When the build has completed, Rename the `Oculus~` folder to `Oculus` to return the folder to normal
-* By default, the Unity WebGL build uses static 960 x 600 pixel dimensions for the content frame. CSS adjustments can be made to the `index.html` file to change how the CEASAR content frame is shown in the browser.
+* By default, the Unity WebGL build uses static 960 x 600 pixel dimensions for the content frame. CSS adjustments can be made to the `index.html` file located in the build folder to change how the CEASAR content frame is shown in the browser. The `index.html` file located in `Assets\HTML` contains CSS that allows the CEASAR content frame to fill the browser window. You can copy this file over the built `index.html` file located in the WebGL build root folder if you have made the WebGL build in a folder named `CEASAR` (otherwise the copied `index.html` file will contain references to file names that do not exsit in the WebGL build folder).
 
 ### Building for Oculus Quest
 To build for Oculus Quest, you need:


### PR DESCRIPTION
This PR adds an index.html file which can be used after the WebGL build process to overwrite the index.html file created by the Unity build.  The new index.html file included with the project contains additional CSS to more efficiently use the browser's vertical and horizontal space.  Additional build instructions have been added to the readme to clarify how to use this file during the build process.