### PR TITLE
Show crash site time in UTC 24

### DIFF
--- a/Assets/Scripts/UI/InfoPanelController.cs
+++ b/Assets/Scripts/UI/InfoPanelController.cs
@@ -49,12 +49,11 @@ public class InfoPanelController : MonoBehaviour
     private void updatePushpinText(Pushpin pin)
     {
         StringBuilder details = new StringBuilder();
-        details.Append(manager.CurrentSimulationTime.ToUniversalTime().ToShortDateString())
+        details.Append(manager.CurrentSimulationTime.ToShortDateString())
             .Append(" ")
-            .Append(manager.CurrentSimulationTime.ToUniversalTime().ToShortTimeString());
+            .Append(manager.CurrentSimulationTime.ToString("HH:mm"));
         details.AppendLine();
         details.Append(manager.CurrentLocationDisplayName);
-
         pushPinDetailsText.GetComponent<TextMeshProUGUI>().SetText(details.ToString());
 
     }


### PR DESCRIPTION
This PR ensures that we use UTC 24 hour time when displaying times to the user in the information panel and in the snapshots.