### PR TITLE
Fix handling of user colors to be more robust (was buggy in web version)

### DIFF
--- a/Assets/Scripts/UserRecord.cs
+++ b/Assets/Scripts/UserRecord.cs
@@ -5,22 +5,22 @@ using System.Collections.Generic;
 
 public class UserRecord
 {
-    public static bool operator ==(UserRecord p1, UserRecord p2) 
+    public static bool operator ==(UserRecord p1, UserRecord p2)
     {
         return p1.Username.Equals(p2.Username);
     }
 
-    public static bool operator !=(UserRecord p1, UserRecord p2) 
+    public static bool operator !=(UserRecord p1, UserRecord p2)
     {
         return !p1.Username.Equals(p2.Username);
     }
-    
+
     readonly private static int COLOR_INDEX = 0;
     readonly private static int ANIMAL_INDEX = 1;
     readonly private static int NUMBER_INDEX = 2;
     readonly private static int GROUP_INDEX = 3;
     readonly private static int NUM_FIELDS = 4;
-    
+
     public const string DEFAULT_USER_COLOR = "red";
     // The username record items:
     public string group;
@@ -122,7 +122,7 @@ public class UserRecord
             return groupPins;
         }
     }
-    
+
     private static List<string> Numbers = new List<string>("1,2,3,4,5,6,7,8,9".Split(','));
     private static List<string> colorNames;
     public static List<string> ColorNames
@@ -183,13 +183,13 @@ public class UserRecord
 
         TextAsset groupList = Resources.Load("groups") as TextAsset;
         JSONObject groupsObject = JSONObject.Create(groupList.text);
-        
+
         groupNames = groupsObject.keys;
         foreach (var g in groupsObject.keys)
         {
             LatLng loc = new LatLng
             {
-                Latitude = groupsObject[g].GetField("latitude").n, 
+                Latitude = groupsObject[g].GetField("latitude").n,
                 Longitude = groupsObject[g].GetField("longitude").n
             };
             DateTime crashDt = DateTime.Parse(groupsObject[g].GetField("crashdatetime").str);
@@ -200,13 +200,14 @@ public class UserRecord
 
         ResourcesLoaded = true;
     }
-    
+
 
     public static string GetColorNameForUsername(string username)
     {
+        string lowerCaseUserName = username.ToLower();
         foreach (string colorName in colorNames)
         {
-            if (username.IndexOf(colorName, System.StringComparison.OrdinalIgnoreCase) >= 0)
+            if (lowerCaseUserName.IndexOf(colorName) >= 0)
             {
                 return colorName;
             }


### PR DESCRIPTION
This PR fixes the handling of mapping user colors to text mesh colors.  Our code was failing in the WebGL version due to case sensitivity issues.  Remove the inconsistent `System.StringComparison.OrdinalIgnoreCase` and replace with a simple `toLower` on the user name string to ensure we find the proper color in the user name.

![image](https://user-images.githubusercontent.com/5126913/127924078-02e8a98f-ee80-4e2f-b8a6-78cc79545e38.png)
