### PR TITLE
Add ability to move in and out from celestial sphere using zoom

### DIFF
--- a/Assets/Scenes/Stars.unity
+++ b/Assets/Scenes/Stars.unity
@@ -43,7 +43,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
+  serializedVersion: 11
   m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -98,8 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_LightingSettings: {fileID: 4890085278179872738, guid: 9502d8c932a1445ef8aab93c1d7768fe,
-    type: 2}
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -119,8 +118,6 @@ NavMeshSettings:
     manualTileSize: 0
     tileSize: 256
     accuratePlacement: 0
-    maxJobWorkers: 0
-    preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
@@ -300,7 +297,7 @@ Animator:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 298385711}
-  m_Enabled: 1
+  m_Enabled: 0
   m_Avatar: {fileID: 0}
   m_Controller: {fileID: 9100000, guid: f4987a9bb89214ce882c8d3e98431446, type: 2}
   m_CullingMode: 0
@@ -596,7 +593,6 @@ MeshRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -621,7 +617,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &7039338957646621140
 MeshFilter:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/UI/UIControlCamera.cs
+++ b/Assets/Scripts/UI/UIControlCamera.cs
@@ -58,7 +58,7 @@ public class UIControlCamera : MonoBehaviour
         {
             if (controlContainer && !controlContainer.activeInHierarchy)
             {
-                controlContainer.SetActive(true);   
+                controlContainer.SetActive(true);
             }
             if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
             {
@@ -125,18 +125,42 @@ public class UIControlCamera : MonoBehaviour
     }
     public void ZoomOut()
     {
-        float fov = mainCam.fieldOfView;
-        if (fov < 75)
+        string sceneName = SceneManager.GetActiveScene().name;
+        if (sceneName == SimulationConstants.SCENE_STARS)
         {
-            mainCam.fieldOfView = fov + 15f;
+            float zPos = mainCam.transform.position.z;
+            if (zPos > -200f)
+            {
+                mainCam.transform.position = new Vector3(0, 0, zPos - 10f);
+            }
+        }
+        else
+        {
+            float fov = mainCam.fieldOfView;
+            if (fov < 75)
+            {
+                mainCam.fieldOfView = fov + 15f;
+            }
         }
     }
     public void ZoomIn()
     {
-        float fov = mainCam.fieldOfView;
-        if (fov > 45)
+        string sceneName = SceneManager.GetActiveScene().name;
+        if (sceneName == SimulationConstants.SCENE_STARS)
         {
-            mainCam.fieldOfView = fov - 15f;
+            float zPos = mainCam.transform.position.z;
+            if (zPos < 0)
+            {
+                mainCam.transform.position = new Vector3(0, 0, zPos + 10f);
+            }
+        }
+        else
+        {
+            float fov = mainCam.fieldOfView;
+            if (fov > 45)
+            {
+                mainCam.fieldOfView = fov - 15f;
+            }
         }
     }
 


### PR DESCRIPTION
This PR changes the functionality of the zoom in/out buttons in the celestial sphere scene.  Rather acting like a digital zoom and changing the camera field of view, we make the zoom act like a tracking shot and we move the camera in and out from the origin position.  This allows us to see outside the celestial sphere so users can have a better understanding of the celestial sphere concept.
![zoom](https://user-images.githubusercontent.com/5126913/127923762-55d99c79-bf3b-485f-96ec-74262b189167.gif)
