### PR TITLE
Add "UTC" to displayed time string

### DIFF
--- a/Assets/Scripts/Core/Pushpin.cs
+++ b/Assets/Scripts/Core/Pushpin.cs
@@ -49,10 +49,10 @@ public class Pushpin
         get
         {
             return this.LocationNameDetail + "\n" + this.SelectedDateTime.ToShortDateString() + " " +
-                   this.SelectedDateTime.ToString("HH:mm:ss");
+                   this.SelectedDateTime.ToString("HH:mm:ss") + " UTC";
         }
     }
-    
+
     public override string ToString()
     {
         return Location.ToString() + " " + SelectedDateTime.ToString();
@@ -61,18 +61,18 @@ public class Pushpin
     public override bool Equals(System.Object obj)
     {
         //Check for null and compare run-time types.
-        if ((obj == null) || ! this.GetType().Equals(obj.GetType())) 
+        if ((obj == null) || ! this.GetType().Equals(obj.GetType()))
         {
             return false;
         }
-        else { 
-            Pushpin p = (Pushpin) obj; 
+        else {
+            Pushpin p = (Pushpin) obj;
             return (Location == p.Location) && (SelectedDateTime == p.SelectedDateTime);
-        }   
+        }
     }
 
     public override int GetHashCode()
-    { 
+    {
         int t = this.SelectedDateTime.Hour + this.SelectedDateTime.Minute + this.SelectedDateTime.Second;
         int ll = (int)this.Location.Latitude + (int)this.Location.Longitude;
         return (t + ll);
@@ -93,7 +93,7 @@ public struct LatLng
     {
         return "" + Latitude.ToString("F2") + "," + Longitude.ToString("F2");
     }
-    
+
     public LatLng(string latlngString)
     {
         float defaultLatitude = 0;
@@ -115,13 +115,13 @@ public struct LatLng
             }
         }
     }
-    
-    public static bool operator ==(LatLng l1, LatLng l2) 
+
+    public static bool operator ==(LatLng l1, LatLng l2)
     {
         return l1.Equals(l2);
     }
 
-    public static bool operator !=(LatLng l1, LatLng l2) 
+    public static bool operator !=(LatLng l1, LatLng l2)
     {
         return !l1.Equals(l2);
     }

--- a/Assets/Scripts/UI/InfoPanelController.cs
+++ b/Assets/Scripts/UI/InfoPanelController.cs
@@ -51,7 +51,8 @@ public class InfoPanelController : MonoBehaviour
         StringBuilder details = new StringBuilder();
         details.Append(manager.CurrentSimulationTime.ToShortDateString())
             .Append(" ")
-            .Append(manager.CurrentSimulationTime.ToString("HH:mm"));
+            .Append(manager.CurrentSimulationTime.ToString("HH:mm"))
+            .Append(" UTC");
         details.AppendLine();
         details.Append(manager.CurrentLocationDisplayName);
         pushPinDetailsText.GetComponent<TextMeshProUGUI>().SetText(details.ToString());


### PR DESCRIPTION
Add "UTC" to displayed time strings to help clarify the time system used in the application.

![image](https://user-images.githubusercontent.com/5126913/128079986-e6fb630f-dee8-4bb1-b096-43a4a12e10f2.png)
