### PR TITLE
Improve string handling when restoring previous login

### DIFF
--- a/Assets/Scripts/UserRecord.cs
+++ b/Assets/Scripts/UserRecord.cs
@@ -266,9 +266,10 @@ public class UserRecord
 
     private static string UsernameListItem(string username, List<string> list)
     {
+        string lowerCaseUserName = username.ToLower();
         foreach (string item in list)
         {
-            if (username.IndexOf(item, System.StringComparison.CurrentCultureIgnoreCase) >= 0)
+            if (lowerCaseUserName.IndexOf(item) >= 0)
             {
                 return item;
             }


### PR DESCRIPTION
This PR fixes the handling of loading the previous login info in the WebGL version.  Our code was failing to load the previous login info in the WebGL version due to case sensitivity issues (similar to a previous issue that we had parsing these strings).  Remove the inconsistent `System.StringComparison.OrdinalIgnoreCase` and replace with a simple `toLower` to ensure string comparison behaves as expected.

![image](https://user-images.githubusercontent.com/5126913/128087679-4feef5f2-452e-4846-8efe-3bad6d713627.png)
