### PR TITLE
Add ability to rotate sphere from movement control in sphere scene

### DIFF
--- a/Assets/Prefabs/UI/InteractionMenu.prefab
+++ b/Assets/Prefabs/UI/InteractionMenu.prefab
@@ -40163,9 +40163,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3438795660351382241}
-        m_MethodName: LookUpDown
-        m_Mode: 4
+      - m_Target: {fileID: 1282574470823667025}
+        m_MethodName: MoveDown
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -40201,9 +40201,9 @@ MonoBehaviour:
   onHoldClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3438795660351382241}
-        m_MethodName: LookUpDown
-        m_Mode: 4
+      - m_Target: {fileID: 1282574470823667025}
+        m_MethodName: MoveDown
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -43414,9 +43414,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3438795660351382241}
-        m_MethodName: LookLeftRight
-        m_Mode: 4
+      - m_Target: {fileID: 1282574470823667025}
+        m_MethodName: MoveLeft
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -43452,9 +43452,9 @@ MonoBehaviour:
   onHoldClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3438795660351382241}
-        m_MethodName: LookLeftRight
-        m_Mode: 4
+      - m_Target: {fileID: 1282574470823667025}
+        m_MethodName: MoveLeft
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -56537,9 +56537,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3438795660351382241}
-        m_MethodName: LookUpDown
-        m_Mode: 4
+      - m_Target: {fileID: 1282574470823667025}
+        m_MethodName: MoveUp
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -56575,9 +56575,9 @@ MonoBehaviour:
   onHoldClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3438795660351382241}
-        m_MethodName: LookUpDown
-        m_Mode: 4
+      - m_Target: {fileID: 1282574470823667025}
+        m_MethodName: MoveUp
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -100149,9 +100149,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3438795660351382241}
-        m_MethodName: LookLeftRight
-        m_Mode: 4
+      - m_Target: {fileID: 1282574470823667025}
+        m_MethodName: MoveRight
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -100187,9 +100187,9 @@ MonoBehaviour:
   onHoldClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3438795660351382241}
-        m_MethodName: LookLeftRight
-        m_Mode: 4
+      - m_Target: {fileID: 1282574470823667025}
+        m_MethodName: MoveRight
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/Scripts/UI/MenuController.cs
+++ b/Assets/Scripts/UI/MenuController.cs
@@ -28,6 +28,8 @@ public class MenuController : MonoBehaviour
     private ConstellationsController constellationsController;
     private GameObject annotationsObject;
 
+    private UIControlCamera cameraControlUI;
+    private float rotateSpeed = 10f;
 
     public GameObject drawModeIndicator;
     public GameObject drawModeOffIndicator;
@@ -166,6 +168,7 @@ public class MenuController : MonoBehaviour
         if (snapshotsController) snapshotsController.Init();
         SceneManager.sceneLoaded += OnSceneLoaded;
         hideAnnotations = false;
+        if (cameraControlUI == null) cameraControlUI = FindObjectOfType<UIControlCamera>();
     }
 
     public void ToggleDrawMode()
@@ -386,6 +389,55 @@ public class MenuController : MonoBehaviour
     {
         if (!constellationsController) constellationsController = FindObjectOfType<ConstellationsController>();
         constellationsController.SelectConstellationByName(SimulationConstants.CONSTELLATIONS_NONE);
+    }
+
+    public void MoveLeft()
+    {
+        string sceneName = SceneManager.GetActiveScene().name;
+        if (sceneName == SimulationConstants.SCENE_STARS)
+        {
+            manager.CelestialSphereObject.transform.Rotate(Vector3.up, rotateSpeed * Time.deltaTime);
+        }
+        else
+        {
+            cameraControlUI.LookLeftRight(-20);
+        }
+    }
+    public void MoveRight()
+    {
+        string sceneName = SceneManager.GetActiveScene().name;
+        if (sceneName == SimulationConstants.SCENE_STARS)
+        {
+            manager.CelestialSphereObject.transform.Rotate(Vector3.down, rotateSpeed * Time.deltaTime);
+        }
+        else
+        {
+            cameraControlUI.LookLeftRight(20);
+        }
+    }
+    public void MoveUp()
+    {
+        string sceneName = SceneManager.GetActiveScene().name;
+        if (sceneName == SimulationConstants.SCENE_STARS)
+        {
+            manager.CelestialSphereObject.transform.Rotate(Vector3.right, rotateSpeed * Time.deltaTime);
+        }
+        else
+        {
+            cameraControlUI.LookUpDown(20);
+        }
+    }
+    public void MoveDown()
+    {
+        string sceneName = SceneManager.GetActiveScene().name;
+        if (sceneName == SimulationConstants.SCENE_STARS)
+        {
+            manager.CelestialSphereObject.transform.Rotate(Vector3.left, rotateSpeed * Time.deltaTime);
+        }
+        else
+        {
+            cameraControlUI.LookUpDown(-20);
+        }
     }
 
     public void LoadEarthScene()


### PR DESCRIPTION
Add the ability to rotate sphere up/down/left/right from the movement controls when in the celestial sphere scene.

![rotate](https://user-images.githubusercontent.com/5126913/128113494-995e05f3-dc99-4e47-9607-937027668fe7.gif)
