### PR TITLE
Update the constellation line thickness

### DIFF
--- a/Assets/Scenes/EarthInteraction.unity
+++ b/Assets/Scenes/EarthInteraction.unity
@@ -43,7 +43,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
+  serializedVersion: 11
   m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -98,8 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_LightingSettings: {fileID: 4890085278179872738, guid: c47a15ff0fb6c4c3cafd193998bae4a4,
-    type: 2}
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -119,8 +118,6 @@ NavMeshSettings:
     manualTileSize: 0
     tileSize: 256
     accuratePlacement: 0
-    maxJobWorkers: 0
-    preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
@@ -473,6 +470,11 @@ PrefabInstance:
         type: 3}
       propertyPath: radius
       value: 1000
+      objectReference: {fileID: 0}
+    - target: {fileID: 5403287526488722156, guid: 6e48567b2e4454f4ab8ea2e7d4122a7f,
+        type: 3}
+      propertyPath: lineWidth
+      value: 0.2
       objectReference: {fileID: 0}
     - target: {fileID: 5403287526488722156, guid: 6e48567b2e4454f4ab8ea2e7d4122a7f,
         type: 3}

--- a/Assets/Scenes/Horizon.unity
+++ b/Assets/Scenes/Horizon.unity
@@ -190,6 +190,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5403287526488722156, guid: 6e48567b2e4454f4ab8ea2e7d4122a7f,
         type: 3}
+      propertyPath: lineWidth
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5403287526488722156, guid: 6e48567b2e4454f4ab8ea2e7d4122a7f,
+        type: 3}
       propertyPath: showEquator
       value: 0
       objectReference: {fileID: 0}

--- a/Assets/Scenes/Stars.unity
+++ b/Assets/Scenes/Stars.unity
@@ -389,6 +389,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5403287526488722156, guid: 6e48567b2e4454f4ab8ea2e7d4122a7f,
         type: 3}
+      propertyPath: lineWidth
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5403287526488722156, guid: 6e48567b2e4454f4ab8ea2e7d4122a7f,
+        type: 3}
       propertyPath: showEquator
       value: 1
       objectReference: {fileID: 0}


### PR DESCRIPTION
This PR double the thickness of the constellation lines so that they render better on a 2D screen (less gaps in lines at different distances and orientations).

![image](https://user-images.githubusercontent.com/5126913/128417687-2fe0ca70-2bfa-48b2-8765-4dcfe59a89b4.png)
