### PR TITLE
Set camera rotation limits so that we do not turn the user upside down

### DIFF
--- a/Assets/Scripts/UI/UIControlCamera.cs
+++ b/Assets/Scripts/UI/UIControlCamera.cs
@@ -93,7 +93,15 @@ public class UIControlCamera : MonoBehaviour
             }
             else
             {
-                mainCam.transform.Rotate(Vector3.left, speed * Time.deltaTime, Space.Self);
+                Vector3 currentRotation = mainCam.transform.localEulerAngles;
+                float xRotation = currentRotation.x;
+                xRotation = xRotation + speed * Time.deltaTime * -1f;
+                // values can be from 270 - 90
+                float highAngle = 270f;
+                float lowAngle = 90f;
+                if (xRotation > lowAngle && xRotation < highAngle)
+                    xRotation = currentRotation.x;
+                mainCam.transform.localRotation = Quaternion.Euler(xRotation, currentRotation.y, currentRotation.z);
             }
         }
     }


### PR DESCRIPTION
This PR sets limits to how far a user can look up or down with the camera in 2D versions of the app.  Previously a user could rotate the camera until they were effectively upside down and the horizon appeared at the top of the screen.  We will now limit the range so that the x rotation is between 270 and 90 degrees (look straight up, look straight down, and anything in between).

The behavior shown below was previously allowed and is now prevented:
![Pasted Image at 2021_08_04_19_54 pm](https://user-images.githubusercontent.com/5126913/128418291-a65d6d8b-3c41-4541-bd35-2c011170887e.png)
