### PR TITLE
179123376 annotation improvements

### DIFF
--- a/Assets/Prefabs/UI/InteractionMenu.prefab
+++ b/Assets/Prefabs/UI/InteractionMenu.prefab
@@ -26488,7 +26488,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -180, y: 310}
+  m_AnchoredPosition: {x: -260, y: 310}
   m_SizeDelta: {x: 80, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &853364602301144760
@@ -85945,6 +85945,9 @@ MonoBehaviour:
   showAnnotationsIndicator: {fileID: 8728923586205098852}
   hideAnnotationsIndicator: {fileID: 845900427345199621}
   annotationsButtonText: {fileID: 1243478679224832560}
+  annotationDrawButton: {fileID: 9059320035563489192}
+  annotationUndoButton: {fileID: 2499463845272353629}
+  annotationNorthPinButton: {fileID: 4428538327212343788}
   menuContainerObject: {fileID: 4480416945259224394}
   informationPanelObject: {fileID: 0}
   showHideMenuToggle: {fileID: 1877320250941385219}
@@ -98959,7 +98962,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -260, y: 310}
+  m_AnchoredPosition: {x: -180, y: 310}
   m_SizeDelta: {x: 80, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3860522038074595600

--- a/Assets/Scripts/AnnotationLine.cs
+++ b/Assets/Scripts/AnnotationLine.cs
@@ -52,6 +52,7 @@ public class AnnotationLine : MonoBehaviour, IPointerDownHandler, IPointerExitHa
         {
             isSelected = false;
             transform.localScale = initialScale;
+            this.GetComponent<Renderer>().material.color = initialColor;
             GetComponent<Collider>().enabled = !drawModeActive;
             isDrawing = drawModeActive;
         }
@@ -68,6 +69,7 @@ public class AnnotationLine : MonoBehaviour, IPointerDownHandler, IPointerExitHa
             else
             {
                 transform.localScale = initialScale;
+                this.GetComponent<Renderer>().material.color = initialColor;
                 isSelected = false;
             }
         }
@@ -97,7 +99,7 @@ public class AnnotationLine : MonoBehaviour, IPointerDownHandler, IPointerExitHa
             else if (holdClickDuration > 0)
             {
                 holdClickDuration = 0;
-                this.GetComponent<Renderer>().material.color = this.initialColor;
+                this.GetComponent<Renderer>().material.color = initialColor;
             }
         }
     }

--- a/Assets/Scripts/AnnotationTool.cs
+++ b/Assets/Scripts/AnnotationTool.cs
@@ -7,9 +7,9 @@ public class AnnotationTool : MonoBehaviour
 {
     private Vector3 startPointForDrawing = Vector3.zero;
     private Vector3 endPointForDrawing = Vector3.zero;
-    
+
     public GameObject annotationLinePrefab;
-    
+
     public float annotationWidth = 1;
     public float annotationHighlightWidthMultiplier = 1.5f;
 
@@ -45,7 +45,7 @@ public class AnnotationTool : MonoBehaviour
                 // start
                 startPointForDrawing = nextPoint;
                 currentAnnotation = Instantiate(annotationLinePrefab, startPointForDrawing, Quaternion.identity, this.transform);
-                
+
             }
             else if (endPointForDrawing == Vector3.zero)
             {
@@ -55,25 +55,26 @@ public class AnnotationTool : MonoBehaviour
                 Vector3 distance = endPointForDrawing - startPointForDrawing;
                 Vector3 scale = new Vector3(annotationWidth, annotationWidth, distance.magnitude );
                 Vector3 midPosition = startPointForDrawing + (distance / 2.0f);
-                
+
                 currentAnnotation.transform.LookAt(endPointForDrawing);
                 currentAnnotation.transform.position = midPosition;
                 currentAnnotation.transform.localScale = scale;
-              
+
                 currentAnnotation.GetComponent<Renderer>().material.color = SimulationManager.Instance.LocalPlayerColor;
                 currentAnnotation.GetComponent<Renderer>().material.SetColor("_OutlineColor", Color.white);
 
                 currentAnnotation.GetComponent<AnnotationLine>().FinishDrawing();
+
                 myAnnotations.Add(currentAnnotation);
                 currentAnnotation.name = getMyAnnotationName(myAnnotations.Count);
-                
+
                 // Broadcast adding an annotation
                 SimulationEvents.Instance.AnnotationAdded.Invoke(
-                    currentAnnotation.transform.localPosition, 
-                    currentAnnotation.transform.localRotation, 
-                    currentAnnotation.transform.localScale, 
+                    currentAnnotation.transform.localPosition,
+                    currentAnnotation.transform.localRotation,
+                    currentAnnotation.transform.localScale,
                     currentAnnotation.name);
-                
+
                 startPointForDrawing = Vector3.zero;
                 endPointForDrawing = Vector3.zero;
                 currentAnnotation = null;
@@ -111,7 +112,7 @@ public class AnnotationTool : MonoBehaviour
         string annotationName = lastAnnotation.name;
         Color c = UserRecord.GetColorForUsername(p.username);
         this.addAnnotation(pos, rot, scale, annotationName, c);
-        
+
     }
     private void addAnnotation(Vector3 pos, Quaternion rot, Vector3 scale, string annotationName, Color playerColor)
     {
@@ -142,7 +143,7 @@ public class AnnotationTool : MonoBehaviour
             StartCoroutine(sendAnnotationDelayed(myAnnotations[i], delay));
         }
     }
-    
+
     IEnumerator sendAnnotationDelayed(GameObject annotation, float delay)
     {
         yield return new WaitForSeconds(delay);
@@ -159,7 +160,7 @@ public class AnnotationTool : MonoBehaviour
             }
         }
     }
-    
+
     public void EndDrawingMode()
     {
         if (startPointForDrawing != Vector3.zero && currentAnnotation != null && endPointForDrawing == Vector3.zero)

--- a/Assets/Scripts/InteractionDetect.cs
+++ b/Assets/Scripts/InteractionDetect.cs
@@ -17,7 +17,7 @@ public class InteractionDetect : MonoBehaviour
     public AnnotationTool annotationTool;
     MenuController mainUIController;
     private PushpinComponent lastPin;
-    
+
     // Start is called before the first frame update
     void Start()
     {
@@ -39,7 +39,7 @@ public class InteractionDetect : MonoBehaviour
             ray = camera.ScreenPointToRay(Input.mousePosition);
             // We have two colliders on Earth, so we collect data on all ray hits
             Physics.RaycastNonAlloc(ray, hits, 100.0F, layerMaskEarth);
-    
+
             // Do something with the object that was hit by the raycast.
             if (Input.GetMouseButtonDown(0) && !EventSystem.current.IsPointerOverGameObject() )
             {
@@ -63,7 +63,7 @@ public class InteractionDetect : MonoBehaviour
                             {
                                 interactionController.ShowEarthMarkerInteraction(hit.point, Quaternion.FromToRotation(Vector3.forward, hit.normal), manager.LocalPlayerColor, true);
                             }
-                            
+
                         }
                         else
                         {
@@ -76,7 +76,7 @@ public class InteractionDetect : MonoBehaviour
                         if (rend == null)
                         {
                             return;
-                        } 
+                        }
                         else
                         {
                             // hit.textureCoord only possible on the Mesh collider
@@ -84,7 +84,7 @@ public class InteractionDetect : MonoBehaviour
                         }
                     }
                 }
-            } 
+            }
         }
         if (mainUIController && mainUIController.IsDrawing && annotationTool)
         {
@@ -92,7 +92,7 @@ public class InteractionDetect : MonoBehaviour
             Physics.Raycast(ray, out hit, manager.SceneRadius);// layerMaskStarsAnnotations);
             if (Input.GetMouseButtonDown(0))
             {
-                if (!EventSystem.current.IsPointerOverGameObject() || hit.point != Vector3.zero)
+                if ((!EventSystem.current.IsPointerOverGameObject() || hit.point != Vector3.zero) && !IsPointerOverUIElement())
                 {
                     float r = SimulationManager.Instance.SceneRadius + 2f;
                     Vector2 mousePos = Input.mousePosition;
@@ -102,5 +102,31 @@ public class InteractionDetect : MonoBehaviour
                 }
             }
         }
+    }
+
+    // Returns 'true' if we touched or hovering on Unity UI element.
+    public static bool IsPointerOverUIElement()
+    {
+        return IsPointerOverUIElement(GetEventSystemRaycastResults());
+    }
+    // Returns 'true' if we touched or hovering on Unity UI element.
+    public static bool IsPointerOverUIElement(List<RaycastResult> eventSystemRayCastResults)
+    {
+        for (int index = 0;  index < eventSystemRayCastResults.Count; index ++)
+        {
+            RaycastResult curRaysastResult = eventSystemRayCastResults [index];
+            if (curRaysastResult.gameObject.layer == LayerMask.NameToLayer("UI"))
+                return true;
+        }
+        return false;
+    }
+    // Gets all event systen raycast results of current mouse or touch position.
+    static List<RaycastResult> GetEventSystemRaycastResults()
+    {
+        PointerEventData eventData = new PointerEventData(EventSystem.current);
+        eventData.position = Input.mousePosition;
+        List<RaycastResult> raysastResults = new List<RaycastResult>();
+        EventSystem.current.RaycastAll(eventData, raysastResults);
+        return raysastResults;
     }
 }

--- a/Assets/Scripts/InteractionDetect.cs
+++ b/Assets/Scripts/InteractionDetect.cs
@@ -104,17 +104,17 @@ public class InteractionDetect : MonoBehaviour
         }
     }
 
-    // Returns 'true' if we touched or hovering on Unity UI element.
+    // Returns 'true' if we touched or are hovering over Unity UI element.
     public static bool IsPointerOverUIElement()
     {
         return IsPointerOverUIElement(GetEventSystemRaycastResults());
     }
-    // Returns 'true' if we touched or hovering on Unity UI element.
-    public static bool IsPointerOverUIElement(List<RaycastResult> eventSystemRayCastResults)
+    // Returns 'true' if we touched or are hovering over Unity UI element.
+    public static bool IsPointerOverUIElement(List<RaycastResult> eventSystemRaycastResults)
     {
-        for (int index = 0;  index < eventSystemRayCastResults.Count; index ++)
+        for (int index = 0;  index < eventSystemRaycastResults.Count; index ++)
         {
-            RaycastResult curRaysastResult = eventSystemRayCastResults [index];
+            RaycastResult curRaysastResult = eventSystemRaycastResults [index];
             if (curRaysastResult.gameObject.layer == LayerMask.NameToLayer("UI"))
                 return true;
         }
@@ -125,8 +125,8 @@ public class InteractionDetect : MonoBehaviour
     {
         PointerEventData eventData = new PointerEventData(EventSystem.current);
         eventData.position = Input.mousePosition;
-        List<RaycastResult> raysastResults = new List<RaycastResult>();
-        EventSystem.current.RaycastAll(eventData, raysastResults);
-        return raysastResults;
+        List<RaycastResult> raycastResults = new List<RaycastResult>();
+        EventSystem.current.RaycastAll(eventData, raycastResults);
+        return raycastResults;
     }
 }

--- a/Assets/Scripts/UI/MenuController.cs
+++ b/Assets/Scripts/UI/MenuController.cs
@@ -36,6 +36,9 @@ public class MenuController : MonoBehaviour
     public GameObject showAnnotationsIndicator;
     public GameObject hideAnnotationsIndicator;
     public TMP_Text annotationsButtonText;
+    public GameObject annotationDrawButton;
+    public GameObject annotationUndoButton;
+    public GameObject annotationNorthPinButton;
 
     private bool _hideAnnotations = false;
     // Make this a property so we can have side effect triggered when the value is changed
@@ -61,7 +64,6 @@ public class MenuController : MonoBehaviour
         }
     }
     private SnapGrid _snapshotGrid;
-
 
     [SerializeField] private GameObject menuContainerObject;
     [SerializeField] private GameObject informationPanelObject;
@@ -152,7 +154,19 @@ public class MenuController : MonoBehaviour
     {
         ClearStarSelection();
         CheckDisplayNorthPin();
-        ToggleAnnotationsVisibility();
+        if (SceneManager.GetActiveScene().name == SimulationConstants.SCENE_STARS)
+        {
+            annotationDrawButton.SetActive(false);
+            annotationUndoButton.SetActive(false);
+            annotationNorthPinButton.SetActive(false);
+        }
+        else
+        {
+            ToggleAnnotationsVisibility();
+            annotationDrawButton.SetActive(true);
+            annotationUndoButton.SetActive(true);
+            annotationNorthPinButton.SetActive(true);
+        }
     }
 
     void OnDisable()
@@ -180,6 +194,7 @@ public class MenuController : MonoBehaviour
     }
     public void UndoAnnotation()
     {
+        hideAnnotations = false;
         if (!annotationTool) annotationTool = FindObjectOfType<AnnotationTool>();
         if (annotationTool)
         {
@@ -195,7 +210,8 @@ public class MenuController : MonoBehaviour
             ToggleDrawMode();
         }
         // If we hide annotations, we can't draw til we turn them back on
-        if (SceneManager.GetActiveScene().name != SimulationConstants.SCENE_HORIZON)
+        if (SceneManager.GetActiveScene().name != SimulationConstants.SCENE_HORIZON &&
+            SceneManager.GetActiveScene().name != SimulationConstants.SCENE_STARS)
         {
             // every other scene we need to hide annotations
             hideAnnotations = true;
@@ -482,4 +498,5 @@ public class MenuController : MonoBehaviour
     {
 
     }
+
 }


### PR DESCRIPTION
This PR adds a handful of improvements to the line annotations.  Changes include:
- when using the annotation Undo button, turn on Show Annotations if it is off so users can see what is being removed.
- when adding annotations, don't add an annotation if the user clicks on something in the UI layer.  This was causing a strange bug where the user would press the Undo button to remove annotations, but if they were still in Draw mode, each Undo click was actually adding a new line annotation pt.  So every two times the user pressed Undo, a new line annotation was being created and hidden behind the undo button.
- show the line annotations by default when the Celestial Sphere scene is shown.
- hide all annotation buttons but show/hide in the Celestial Sphere scene.
- Fix some cases where the original annotation color was not being restored when the user ended a delete click+hold early.