### PR TITLE
Update sphere zoom controls to move sphere instead of camera

### DIFF
--- a/Assets/Prefabs/UI/InteractionMenu.prefab
+++ b/Assets/Prefabs/UI/InteractionMenu.prefab
@@ -11179,7 +11179,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3438795660351382241}
+      - m_Target: {fileID: 1282574470823667025}
         m_MethodName: ZoomOut
         m_Mode: 1
         m_Arguments:
@@ -54939,7 +54939,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3438795660351382241}
+      - m_Target: {fileID: 1282574470823667025}
         m_MethodName: ZoomIn
         m_Mode: 1
         m_Arguments:

--- a/Assets/Scripts/UI/MenuController.cs
+++ b/Assets/Scripts/UI/MenuController.cs
@@ -455,6 +455,34 @@ public class MenuController : MonoBehaviour
             cameraControlUI.LookUpDown(-20);
         }
     }
+    public void ZoomOut()
+    {
+        string sceneName = SceneManager.GetActiveScene().name;
+        if (sceneName == SimulationConstants.SCENE_STARS)
+        {
+            Vector3 currPos = manager.CelestialSphereObject.transform.position;
+            if (currPos.z < 200f)
+                manager.CelestialSphereObject.transform.position = new Vector3(currPos.x, currPos.y, currPos.z + 10f);
+        }
+        else
+        {
+            cameraControlUI.ZoomOut();
+        }
+    }
+    public void ZoomIn()
+    {
+        string sceneName = SceneManager.GetActiveScene().name;
+        if (sceneName == SimulationConstants.SCENE_STARS)
+        {
+            Vector3 currPos = manager.CelestialSphereObject.transform.position;
+            if (currPos.z > 0)
+                manager.CelestialSphereObject.transform.position = new Vector3(currPos.x, currPos.y, currPos.z - 10f);
+        }
+        else
+        {
+            cameraControlUI.ZoomIn();
+        }
+    }
 
     public void LoadEarthScene()
     {

--- a/Assets/Scripts/UI/UIControlCamera.cs
+++ b/Assets/Scripts/UI/UIControlCamera.cs
@@ -133,42 +133,18 @@ public class UIControlCamera : MonoBehaviour
     }
     public void ZoomOut()
     {
-        string sceneName = SceneManager.GetActiveScene().name;
-        if (sceneName == SimulationConstants.SCENE_STARS)
+        float fov = mainCam.fieldOfView;
+        if (fov < 75)
         {
-            float zPos = mainCam.transform.position.z;
-            if (zPos > -200f)
-            {
-                mainCam.transform.position = new Vector3(0, 0, zPos - 10f);
-            }
-        }
-        else
-        {
-            float fov = mainCam.fieldOfView;
-            if (fov < 75)
-            {
-                mainCam.fieldOfView = fov + 15f;
-            }
+            mainCam.fieldOfView = fov + 15f;
         }
     }
     public void ZoomIn()
     {
-        string sceneName = SceneManager.GetActiveScene().name;
-        if (sceneName == SimulationConstants.SCENE_STARS)
+        float fov = mainCam.fieldOfView;
+        if (fov > 45)
         {
-            float zPos = mainCam.transform.position.z;
-            if (zPos < 0)
-            {
-                mainCam.transform.position = new Vector3(0, 0, zPos + 10f);
-            }
-        }
-        else
-        {
-            float fov = mainCam.fieldOfView;
-            if (fov > 45)
-            {
-                mainCam.fieldOfView = fov - 15f;
-            }
+            mainCam.fieldOfView = fov - 15f;
         }
     }
 


### PR DESCRIPTION
This PR changes the sphere zoom so that we move the sphere itself rather than the camera.  This change has no effect on what the user sees, but is made in anticipation of adding the sphere zoom feature to the AR branch.  In the AR case we cannot move the camera since it is tied to the user headset position.  Instead, we need to move the sphere itself to achieve a zoom out/zoom in feature.