### PR TITLE
Add ability to enable movement button and set rotation speed in MenuController

### DIFF
--- a/Assets/Prefabs/UI/InteractionMenu.prefab
+++ b/Assets/Prefabs/UI/InteractionMenu.prefab
@@ -85940,6 +85940,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8bdbb8159a2da4c788bf3adf8aecebae, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  rotateSpeed: 10
   drawModeIndicator: {fileID: 3730541923119052999}
   drawModeOffIndicator: {fileID: 2636350217345473775}
   showAnnotationsIndicator: {fileID: 8728923586205098852}
@@ -85948,6 +85949,7 @@ MonoBehaviour:
   annotationDrawButton: {fileID: 9059320035563489192}
   annotationUndoButton: {fileID: 2499463845272353629}
   annotationNorthPinButton: {fileID: 4428538327212343788}
+  movementButton: {fileID: 7878016313495767044}
   menuContainerObject: {fileID: 4480416945259224394}
   informationPanelObject: {fileID: 0}
   showHideMenuToggle: {fileID: 1877320250941385219}

--- a/Assets/Scripts/SimulationManagerComponent.cs
+++ b/Assets/Scripts/SimulationManagerComponent.cs
@@ -64,6 +64,12 @@ public class SimulationManagerComponent : MonoBehaviour
     private SceneLoader sceneLoaderPrefab;
     private SceneLoader sceneLoader;
 
+    // Settings for menu
+    [SerializeField]
+    private bool allowMovement = true;
+    [SerializeField]
+    private float rotateSpeed = 10f;
+
     private void Awake()
     {
         manager = SimulationManager.Instance;
@@ -106,7 +112,7 @@ public class SimulationManagerComponent : MonoBehaviour
         {
             sceneLoader = Instantiate(sceneLoaderPrefab);
         }
-        
+
         if (manager.NetworkControllerComponent == null)
         {
             if (FindObjectOfType<NetworkController>() != null)
@@ -179,22 +185,22 @@ public class SimulationManagerComponent : MonoBehaviour
                 manager.ConstellationsControllerComponent.SetSceneParameters(lineWidth, showConstellationConnections);
             }
         }
-        if (!manager.MainMenu) 
+        if (!manager.MainMenu)
         {
             MenuController sceneMenu = FindObjectOfType<MenuController>();
             if (!sceneMenu)
             {
                 Instantiate(mainUIPrefab);
-            } else
-            {
-                manager.MainMenu = sceneMenu;
+                sceneMenu = FindObjectOfType<MenuController>();
             }
-               
-            
+            manager.MainMenu = sceneMenu;
+
             manager.NetworkControllerComponent.Setup();
-        } 
-       
-        if (!manager.InfoPanel) 
+        }
+        manager.MainMenu.movementButton.SetActive(allowMovement);
+        manager.MainMenu.rotateSpeed = rotateSpeed;
+
+        if (!manager.InfoPanel)
         {
             InfoPanelController sceneInfoPanel = FindObjectOfType<InfoPanelController>();
             if (!sceneInfoPanel)
@@ -205,10 +211,10 @@ public class SimulationManagerComponent : MonoBehaviour
             {
                 manager.InfoPanel = sceneInfoPanel;
             }
-            
-        } 
+
+        }
         sceneLoader.SetupCameras();
-        
+
     }
 
 #if UNITY_WSA

--- a/Assets/Scripts/UI/MenuController.cs
+++ b/Assets/Scripts/UI/MenuController.cs
@@ -29,7 +29,7 @@ public class MenuController : MonoBehaviour
     private GameObject annotationsObject;
 
     private UIControlCamera cameraControlUI;
-    private float rotateSpeed = 10f;
+    public float rotateSpeed = 10f;
 
     public GameObject drawModeIndicator;
     public GameObject drawModeOffIndicator;
@@ -39,6 +39,8 @@ public class MenuController : MonoBehaviour
     public GameObject annotationDrawButton;
     public GameObject annotationUndoButton;
     public GameObject annotationNorthPinButton;
+
+    public GameObject movementButton;
 
     private bool _hideAnnotations = false;
     // Make this a property so we can have side effect triggered when the value is changed
@@ -461,7 +463,7 @@ public class MenuController : MonoBehaviour
         if (sceneName == SimulationConstants.SCENE_STARS)
         {
             Vector3 currPos = manager.CelestialSphereObject.transform.position;
-            if (currPos.z < 200f)
+            if (currPos.z < 300f)
                 manager.CelestialSphereObject.transform.position = new Vector3(currPos.x, currPos.y, currPos.z + 10f);
         }
         else


### PR DESCRIPTION
This PR adds a few small additions that were needed for the HL7 star scene.  These changes let us turn on/off the movement controls and set the rotation speed for the star scene.