### PR TITLE
Communicate date/time changes to other users within the group

### DIFF
--- a/Assets/Scripts/UI/InfoPanelController.cs
+++ b/Assets/Scripts/UI/InfoPanelController.cs
@@ -209,36 +209,39 @@ public class InfoPanelController : MonoBehaviour
     {
         // Setting simulation time updates Local User Pin
         manager.CurrentSimulationTime = manager.CurrentSimulationTime.AddYears(yearChange);
-        events.PushPinSelected.Invoke(manager.LocalPlayerPin);
-        events.SimulationTimeChanged.Invoke();
+        BroadcastTimeChange();
     }
 
     public void ChangeMonth(int monthChange)
     {
         // Setting simulation time updates Local User Pin
         manager.CurrentSimulationTime = manager.CurrentSimulationTime.AddMonths(monthChange);
-        events.PushPinSelected.Invoke(manager.LocalPlayerPin);
-        events.SimulationTimeChanged.Invoke();
+        BroadcastTimeChange();
     }
 
     public void ChangeDay(int dayChange)
     {
         manager.CurrentSimulationTime = manager.CurrentSimulationTime.AddDays(dayChange);
-        events.PushPinSelected.Invoke(manager.LocalPlayerPin);
-        events.SimulationTimeChanged.Invoke();
+         BroadcastTimeChange();
     }
 
     public void ChangeHour(int hourChange)
     {
         manager.CurrentSimulationTime = manager.CurrentSimulationTime.AddHours(hourChange);
-        events.PushPinSelected.Invoke(manager.LocalPlayerPin);
-        events.SimulationTimeChanged.Invoke();
+        BroadcastTimeChange();
     }
 
     public void ChangeMinute(int minuteChange)
     {
         manager.CurrentSimulationTime = manager.CurrentSimulationTime.AddMinutes(minuteChange);
+        BroadcastTimeChange();
+    }
+
+    public void BroadcastTimeChange()
+    {
         events.PushPinSelected.Invoke(manager.LocalPlayerPin);
+        // broadcast the update to remote players
+        SimulationEvents.Instance.PushPinUpdated.Invoke(manager.LocalPlayerPin, manager.LocalPlayerLookDirection);
         events.SimulationTimeChanged.Invoke();
     }
 

--- a/Assets/Scripts/UI/MenuController.cs
+++ b/Assets/Scripts/UI/MenuController.cs
@@ -239,42 +239,6 @@ public class MenuController : MonoBehaviour
             SceneManager.LoadScene("Horizon");
         }
     }
-    public void ChangeYear(int yearChange)
-    {
-        // Setting simulation time updates Local User Pin
-        manager.CurrentSimulationTime = manager.CurrentSimulationTime.AddYears(yearChange);
-        events.PushPinSelected.Invoke(manager.LocalPlayerPin);
-        events.SimulationTimeChanged.Invoke();
-    }
-
-    public void ChangeMonth(int monthChange)
-    {
-        // Setting simulation time updates Local User Pin
-        manager.CurrentSimulationTime = manager.CurrentSimulationTime.AddMonths(monthChange);
-        events.PushPinSelected.Invoke(manager.LocalPlayerPin);
-        events.SimulationTimeChanged.Invoke();
-    }
-
-    public void ChangeDay(int dayChange)
-    {
-        manager.CurrentSimulationTime = manager.CurrentSimulationTime.AddDays(dayChange);
-        events.PushPinSelected.Invoke(manager.LocalPlayerPin);
-        events.SimulationTimeChanged.Invoke();
-    }
-
-    public void ChangeHour(int hourChange)
-    {
-        manager.CurrentSimulationTime = manager.CurrentSimulationTime.AddHours(hourChange);
-        events.PushPinSelected.Invoke(manager.LocalPlayerPin);
-        events.SimulationTimeChanged.Invoke();
-    }
-
-    public void ChangeMinute(int minuteChange)
-    {
-        manager.CurrentSimulationTime = manager.CurrentSimulationTime.AddMinutes(minuteChange);
-        events.PushPinSelected.Invoke(manager.LocalPlayerPin);
-        events.SimulationTimeChanged.Invoke();
-    }
 
     public void ClearStarSelection()
     {

--- a/Assets/Tests/TestMenuFunctions.cs
+++ b/Assets/Tests/TestMenuFunctions.cs
@@ -10,7 +10,8 @@ public class TestMenuFunctions
     private SimulationManager manager;
     private SimulationManagerComponent simController;
     private MenuController menuPanel;
-    
+    private InfoPanelController infoPanel;
+
     [UnitySetUp]
     public IEnumerator SetUp()
     {
@@ -27,6 +28,18 @@ public class TestMenuFunctions
             if (menuPanel == null)
             {
                 menuPanel = new GameObject().AddComponent<MenuController>();
+            }
+        }
+    }
+
+    private void setupInfo()
+    {
+        if (infoPanel == null)
+        {
+            infoPanel = GameObject.FindObjectOfType<InfoPanelController>();
+            if (infoPanel == null)
+            {
+                infoPanel = new GameObject().AddComponent<InfoPanelController>();
             }
         }
     }
@@ -53,34 +66,34 @@ public class TestMenuFunctions
         int currentMonth = SimulationManager.Instance.CurrentSimulationTime.Month;
         int currentDay = SimulationManager.Instance.CurrentSimulationTime.DayOfYear;
 
-        if (menuPanel == null)
+        if (infoPanel == null)
         {
-            menuPanel = GameObject.FindObjectOfType<MenuController>();
-            if (menuPanel == null)
+            infoPanel = GameObject.FindObjectOfType<InfoPanelController>();
+            if (infoPanel == null)
             {
-                menuPanel = new GameObject().AddComponent<MenuController>();
+                infoPanel = new GameObject().AddComponent<InfoPanelController>();
             }
         }
 
-        menuPanel.ChangeYear(1);
+        infoPanel.ChangeYear(1);
         Assert.That(SimulationManager.Instance.CurrentSimulationTime.Year > currentYear);
-        menuPanel.ChangeYear(-2);
+        infoPanel.ChangeYear(-2);
         Assert.That(SimulationManager.Instance.CurrentSimulationTime.Year < currentYear);
 
         if (currentMonth != 12)
         {
-            menuPanel.ChangeMonth(1);
+            infoPanel.ChangeMonth(1);
             Assert.That(SimulationManager.Instance.CurrentSimulationTime.Month > currentMonth);
         }
-        menuPanel.ChangeMonth(-1);
+        infoPanel.ChangeMonth(-1);
         Assert.That(SimulationManager.Instance.CurrentSimulationTime.Month <= currentMonth);
 
         if (currentDay != 365)
         {
-            menuPanel.ChangeDay(1);
+            infoPanel.ChangeDay(1);
             Assert.That(SimulationManager.Instance.CurrentSimulationTime.DayOfYear > currentDay);
         }
-        menuPanel.ChangeDay(-1);
+        infoPanel.ChangeDay(-1);
         Assert.That(SimulationManager.Instance.CurrentSimulationTime.DayOfYear <= currentDay);
     }
 


### PR DESCRIPTION
This PR fixes a bug where data/time changes were not being communicated to other users within the group.  If a user A changed the data/time and then user B chose to move to user A's location/date/time, user B would not have the latest date/time information to move to the correct sphere orientation.  This PR also removes some obsolete code that was causing confusion. 