### PR TITLE
Constellation and star selection fixes

### DIFF
--- a/Assets/Prefabs/ConstellationConnection.prefab
+++ b/Assets/Prefabs/ConstellationConnection.prefab
@@ -54,10 +54,11 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 07edf9c2724793f41ac1572e8f445421, type: 2}
+  - {fileID: 2100000, guid: 33570541f8dac4b9aaa41e8316bb1631, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Scripts/Constellation.cs
+++ b/Assets/Scripts/Constellation.cs
@@ -18,24 +18,27 @@ public class Constellation : MonoBehaviour
 
     public GameObject constellationConnectionPrefab;
 
+    public string playerName;
+
     public void AddStar(GameObject star)
     {
         stars.Add(star);
     }
+
     public void AddConstellationConnection(ConstellationConnection conn)
     {
         constellationConnections.Add(conn);
     }
 
-    public void Highlight(bool highlight, Color userHighlightColor)
+    public void HighlightConstellationLines(bool highlight, Color userHighlightColor)
     {
-        // foreach (GameObject starObject in stars)
         foreach (GameObject connectionObject in constellationLines)
         {
             connectionObject.GetComponent<MeshRenderer>().material.color = highlight ? userHighlightColor : neutralColor;
         }
     }
-    public void Highlight(bool highlight)
+
+    public void HighlightConstellationStars(bool highlight)
     {
         foreach (GameObject starObject in stars)
         {

--- a/Assets/Scripts/Constellation.cs
+++ b/Assets/Scripts/Constellation.cs
@@ -32,7 +32,7 @@ public class Constellation : MonoBehaviour
         // foreach (GameObject starObject in stars)
         foreach (GameObject connectionObject in constellationLines)
         {
-            Utils.SetObjectColor(connectionObject, highlight ? userHighlightColor : neutralColor);
+            connectionObject.GetComponent<MeshRenderer>().material.color = highlight ? userHighlightColor : neutralColor;
         }
     }
     public void Highlight(bool highlight)

--- a/Assets/Scripts/StarComponent.cs
+++ b/Assets/Scripts/StarComponent.cs
@@ -128,7 +128,7 @@ public class StarComponent : MonoBehaviour, IPointerDownHandler, IPointerExitHan
 
             if (constellationsController)
             {
-                constellationsController.HighlightSingleConstellation(starData.ConstellationFullName, playerColor);
+                constellationsController.HighlightSingleConstellation(starData.ConstellationFullName, playerColor, playerName);
             }
 
             // make sure it's visible

--- a/Assets/Scripts/StarComponent.cs
+++ b/Assets/Scripts/StarComponent.cs
@@ -150,6 +150,9 @@ public class StarComponent : MonoBehaviour, IPointerDownHandler, IPointerExitHan
 
     private void CreateFloatingInfoPanel(string playerName, Color playerColor)
     {
+        if (FloatingInfoPanel)
+            Destroy(FloatingInfoPanel);
+
         // make a new floating info panel that is a child of the star
         FloatingInfoPanel = Instantiate(FloatingInfoPanelPrefab, new Vector3(0, -8f, 6f), new Quaternion(0, 0, 0, 0), this.transform);
         FloatingInfoPanel.transform.localPosition = new Vector3(0, -6f, 5f);

--- a/Assets/Scripts/UnusedCode/ConstellationDropdown.cs
+++ b/Assets/Scripts/UnusedCode/ConstellationDropdown.cs
@@ -28,7 +28,7 @@ public class ConstellationDropdown : MonoBehaviour
     {
         string constellationName = change.captionText.text;
         CCDebug.Log("Selected constellation " + constellationName, LogLevel.Info, LogMessageCategory.Interaction);
-        
+
         if (constellationsController)
         {
             if (constellationName.ToLower() == "all")
@@ -54,16 +54,16 @@ public class ConstellationDropdown : MonoBehaviour
                     DataController dc = manager.DataControllerComponent;
                     StarComponent sc = dc.GetStarById(brightestStar.uniqueId);
                     manager.CurrentlySelectedStar = sc;
-                    
+
                     // update legacy UI
                    updateStarPanel(true);
-                    
+
                     // broadcast selection
                     InteractionController interactionController = FindObjectOfType<InteractionController>();
                     interactionController.ShowCelestialObjectInteraction(brightestStar.ProperName,
                         brightestStar.Constellation, brightestStar.uniqueId, true);
                 }
-                constellationsController.HighlightSingleConstellation(constellationName, manager.LocalPlayerColor);
+                constellationsController.HighlightSingleConstellation(constellationName, manager.LocalPlayerColor, manager.LocalUsername);
             }
         }
     }

--- a/Assets/Scripts/UnusedCode/StarInfoPanel.cs
+++ b/Assets/Scripts/UnusedCode/StarInfoPanel.cs
@@ -8,7 +8,7 @@ public class StarInfoPanel : MonoBehaviour
 {
     private SimulationManager manager;
     public TextMeshProUGUI starInfoText;
-    
+
     public void Setup()
     {
         manager = SimulationManager.Instance;
@@ -23,7 +23,7 @@ public class StarInfoPanel : MonoBehaviour
             ConstellationsController constellationsController = FindObjectOfType<ConstellationsController>();
             if (constellationsController)
             {
-                constellationsController.HighlightSingleConstellation(manager.CurrentlySelectedStar.starData.ConstellationFullName);
+                constellationsController.HighlightSingleConstellation(manager.CurrentlySelectedStar.starData.ConstellationFullName, new Color(0, 0, 0), "");
             }
         }
     }
@@ -48,8 +48,8 @@ public class StarInfoPanel : MonoBehaviour
             // description.Append("Flamsteed Des: ").AppendLine(starData.FlamsteedDesignation.Length > 0 ? starData.FlamsteedDesignation : "N/A");
             description.Append("m: ").AppendLine(starData.Mag.ToString());
             starInfoText.text = description.ToString();
-        } 
-        else 
+        }
+        else
         {
             starInfoText.text = "";
         }


### PR DESCRIPTION
This PR includes a handful of fixes to the constellation and star selection.  Changes include:
- Allow multiple constellations to be selected - one per each user.  Two users, A and B, can both select a unique constellation, this selection information will be communicated across the network, and both constellations will appear selected for both users.  This is now more in line with how the floating star panels work (each user can make a selection and other users can see it).
- Fix bug that caused constellation connection line colors to be incorrect (there was a shader bug that had been there for a while but it was magnified by the new colors).
- Fix bug that caused multiple clicks on stars to create multiple floating info panels.  Always destroy existing panel before making new one.
- minor refactoring of function names in constellation class to make function behavior more obvious.