### PR TITLE
Turn markers off in star scene

### DIFF
--- a/Assets/Scenes/Stars.unity
+++ b/Assets/Scenes/Stars.unity
@@ -400,7 +400,7 @@ PrefabInstance:
     - target: {fileID: 5403287526488722156, guid: 6e48567b2e4454f4ab8ea2e7d4122a7f,
         type: 3}
       propertyPath: showMarkers
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5403287526488722156, guid: 6e48567b2e4454f4ab8ea2e7d4122a7f,
         type: 3}


### PR DESCRIPTION
Remove the VE, NCP, and SCP markers from the star scene.

![image](https://user-images.githubusercontent.com/5126913/130389267-0f7f0fde-dc43-4e7d-88b8-8b99dd0be985.png)
