### PR TITLE
Curved annotations

### DIFF
--- a/Assets/Prefabs/CelestialSphere.prefab
+++ b/Assets/Prefabs/CelestialSphere.prefab
@@ -164,7 +164,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4780620506299681866}
-  - component: {fileID: 4780620506299681867}
   - component: {fileID: 6157259189123901154}
   m_Layer: 0
   m_Name: AnnotationTool
@@ -187,103 +186,6 @@ Transform:
   m_Father: {fileID: 3593076565269543296}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!120 &4780620506299681867
-LineRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4780620506299681864}
-  m_Enabled: 0
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 0
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 82f338a4b2b287f4fa01c37dff6a96b7, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Positions:
-  - {x: 0, y: 0, z: 0}
-  - {x: 0, y: 0, z: 1}
-  m_Parameters:
-    serializedVersion: 3
-    widthMultiplier: 1
-    widthCurve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    colorGradient:
-      serializedVersion: 2
-      key0: {r: 1, g: 1, b: 1, a: 1}
-      key1: {r: 1, g: 1, b: 1, a: 1}
-      key2: {r: 0, g: 0, b: 0, a: 0}
-      key3: {r: 0, g: 0, b: 0, a: 0}
-      key4: {r: 0, g: 0, b: 0, a: 0}
-      key5: {r: 0, g: 0, b: 0, a: 0}
-      key6: {r: 0, g: 0, b: 0, a: 0}
-      key7: {r: 0, g: 0, b: 0, a: 0}
-      ctime0: 0
-      ctime1: 65535
-      ctime2: 0
-      ctime3: 0
-      ctime4: 0
-      ctime5: 0
-      ctime6: 0
-      ctime7: 0
-      atime0: 0
-      atime1: 65535
-      atime2: 0
-      atime3: 0
-      atime4: 0
-      atime5: 0
-      atime6: 0
-      atime7: 0
-      m_Mode: 0
-      m_NumColorKeys: 2
-      m_NumAlphaKeys: 2
-    numCornerVertices: 0
-    numCapVertices: 0
-    alignment: 0
-    textureMode: 0
-    shadowBias: 0.5
-    generateLightingData: 0
-  m_UseWorldSpace: 1
-  m_Loop: 0
 --- !u!114 &6157259189123901154
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -296,9 +198,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3def862afb2dcb34680f8069f05ab13d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  annotationLinePrefab: {fileID: 2034434946690713381, guid: 80dd72a098901304eaefa835cfebb414,
-    type: 3}
-  annotationLineHighlightPrefab: {fileID: 2034434946690713381, guid: 3c5f44bbfc4184a08a643cbddf2a8ebd,
+  annotationLinePrefab: {fileID: 2034434946690713381, guid: d431bc47d484b8f46b70044f504dc82e,
     type: 3}
   annotationWidth: 0.5
   annotationHighlightWidthMultiplier: 2
+  annotationMaterial: {fileID: 2100000, guid: 07edf9c2724793f41ac1572e8f445421, type: 2}

--- a/Assets/Prefabs/Interactions/AnnotationLineRender.prefab
+++ b/Assets/Prefabs/Interactions/AnnotationLineRender.prefab
@@ -1,0 +1,126 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2034434946690713381
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7778931955663833681}
+  - component: {fileID: 8533638169546431535}
+  m_Layer: 19
+  m_Name: AnnotationLineRender
+  m_TagString: Annotation
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7778931955663833681
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2034434946690713381}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7206150125662666717}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8533638169546431535
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2034434946690713381}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 397d982d2e83c470d964791a61fced57, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  StartPoint: {fileID: 6686780283819900467}
+--- !u!1 &6686780283819900467
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7206150125662666717}
+  - component: {fileID: 4254448055156813443}
+  - component: {fileID: 9047085153182322936}
+  m_Layer: 0
+  m_Name: StartPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7206150125662666717
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6686780283819900467}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7778931955663833681}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4254448055156813443
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6686780283819900467}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &9047085153182322936
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6686780283819900467}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 33570541f8dac4b9aaa41e8316bb1631, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0

--- a/Assets/Prefabs/Interactions/AnnotationLineRender.prefab.meta
+++ b/Assets/Prefabs/Interactions/AnnotationLineRender.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d431bc47d484b8f46b70044f504dc82e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/EarthInteraction.unity
+++ b/Assets/Scenes/EarthInteraction.unity
@@ -488,6 +488,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5403287526488722156, guid: 6e48567b2e4454f4ab8ea2e7d4122a7f,
         type: 3}
+      propertyPath: annotationWidthMultiplier
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 5403287526488722156, guid: 6e48567b2e4454f4ab8ea2e7d4122a7f,
+        type: 3}
       propertyPath: interactionControllerPrefab
       value: 
       objectReference: {fileID: 1113959076393538667, guid: a50af537ddde54b77b38046cc7102d8f,

--- a/Assets/Scenes/Horizon.unity
+++ b/Assets/Scenes/Horizon.unity
@@ -231,6 +231,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5403287526488722156, guid: 6e48567b2e4454f4ab8ea2e7d4122a7f,
         type: 3}
+      propertyPath: annotationWidthMultiplier
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5403287526488722156, guid: 6e48567b2e4454f4ab8ea2e7d4122a7f,
+        type: 3}
       propertyPath: showConstellationConnections
       value: 0
       objectReference: {fileID: 0}

--- a/Assets/Scenes/Stars.unity
+++ b/Assets/Scenes/Stars.unity
@@ -419,6 +419,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5403287526488722156, guid: 6e48567b2e4454f4ab8ea2e7d4122a7f,
         type: 3}
+      propertyPath: annotationWidthMultiplier
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5403287526488722156, guid: 6e48567b2e4454f4ab8ea2e7d4122a7f,
+        type: 3}
       propertyPath: showConstellationConnections
       value: 1
       objectReference: {fileID: 0}

--- a/Assets/Scripts/AnnotationLine.cs
+++ b/Assets/Scripts/AnnotationLine.cs
@@ -7,16 +7,17 @@ using UnityEngine.EventSystems;
 public class AnnotationLine : MonoBehaviour, IPointerDownHandler, IPointerExitHandler, IPointerEnterHandler
 {
     private float hoverSize = 1.5f;
-    private Vector3 initialScale = Vector3.one;
-    private Vector3 hoverScale = Vector3.one;
     private bool isSelected = false;
-    private ParticleSystem selectedParticles;
     private bool isDrawing = true; // annotations are only added when drawing is enabled
     private float holdClickDuration = 0;
     private float holdToDeleteTime = 1f;
-    private float startParticleSpeed = 0.12f;
     private AnnotationTool _annotationTool;
     private Color initialColor;
+    private float initialLineRendererWidth = 0;
+    private float hoverLineRendererWidth = 0;
+    public GameObject StartPoint;
+    public Vector3 StartPos;
+    public Vector3 EndPos;
 
     public bool IsSelected {
         get { return isSelected; }
@@ -28,17 +29,24 @@ public class AnnotationLine : MonoBehaviour, IPointerDownHandler, IPointerExitHa
         if (isSelected)
         {
             HoldToDeleteAnnotation(Input.GetMouseButton(0));
-
         }
     }
+    public void StartDrawing(Vector3 startPos)
+    {
+        if (StartPoint) StartPoint.transform.position = startPos;
+    }
+    public void RemoveStartPoint()
+    {
+        Destroy(StartPoint);
+    }
+
     public void FinishDrawing()
     {
-        initialScale = transform.localScale;
-        hoverScale = new Vector3(initialScale.x * hoverSize, initialScale.y * hoverSize, initialScale.z);
-        selectedParticles = GetComponent<ParticleSystem>();
+        initialLineRendererWidth = this.GetComponent<LineRenderer>().startWidth;
+        hoverLineRendererWidth = initialLineRendererWidth * hoverSize;
+        initialColor = this.GetComponent<Renderer>().material.color;
         if (_annotationTool == null) _annotationTool = FindObjectOfType<AnnotationTool>();
         SimulationEvents.Instance.DrawMode.AddListener(HandleDrawModeToggle);
-        initialColor = this.GetComponent<Renderer>().material.color;
     }
 
     private void OnDisable()
@@ -51,8 +59,9 @@ public class AnnotationLine : MonoBehaviour, IPointerDownHandler, IPointerExitHa
         if (isDrawing != drawModeActive)
         {
             isSelected = false;
-            transform.localScale = initialScale;
-            this.GetComponent<Renderer>().material.color = initialColor;
+            this.GetComponent<LineRenderer>().startWidth = initialLineRendererWidth;
+            this.GetComponent<LineRenderer>().endWidth = initialLineRendererWidth;
+            this.GetComponent<LineRenderer>().material.color = initialColor;
             GetComponent<Collider>().enabled = !drawModeActive;
             isDrawing = drawModeActive;
         }
@@ -63,13 +72,15 @@ public class AnnotationLine : MonoBehaviour, IPointerDownHandler, IPointerExitHa
         {
             if (showHighlight)
             {
-                transform.localScale = hoverScale;
+                this.GetComponent<LineRenderer>().startWidth = hoverLineRendererWidth;
+                this.GetComponent<LineRenderer>().endWidth = hoverLineRendererWidth;
                 isSelected = true;
             }
             else
             {
-                transform.localScale = initialScale;
-                this.GetComponent<Renderer>().material.color = initialColor;
+                this.GetComponent<LineRenderer>().startWidth = initialLineRendererWidth;
+                this.GetComponent<LineRenderer>().endWidth = initialLineRendererWidth;
+                this.GetComponent<LineRenderer>().material.color = initialColor;
                 isSelected = false;
             }
         }
@@ -94,12 +105,12 @@ public class AnnotationLine : MonoBehaviour, IPointerDownHandler, IPointerExitHa
                 float g = Mathf.Max(0, currentColor.g + Time.deltaTime);
                 float b = Mathf.Max(0, currentColor.b + Time.deltaTime);
                 Color fadeColor = new Color(r, g, b, 1f);
-                this.GetComponent<Renderer>().material.color = fadeColor;
+                this.GetComponent<LineRenderer>().material.color = fadeColor;
             }
             else if (holdClickDuration > 0)
             {
                 holdClickDuration = 0;
-                this.GetComponent<Renderer>().material.color = initialColor;
+               this.GetComponent<LineRenderer>().material.color = initialColor;
             }
         }
     }

--- a/Assets/Scripts/AnnotationTool.cs
+++ b/Assets/Scripts/AnnotationTool.cs
@@ -18,6 +18,8 @@ public class AnnotationTool : MonoBehaviour
 
     public Material annotationMaterial;
 
+    public float annotationWidthMultiplier = 1f;
+
     public bool IsMyAnnotation(GameObject annotationLine)
     {
         return myAnnotations.Contains(annotationLine);
@@ -90,8 +92,8 @@ public class AnnotationTool : MonoBehaviour
         MeshCollider meshColliderArc = _currentAnnotation.AddComponent<MeshCollider>();
         Mesh mesh = new Mesh();
         lineRendererArc.useWorldSpace = false;
-        lineRendererArc.startWidth = annotationWidth * 2f;
-        lineRendererArc.endWidth = annotationWidth * 2f;
+        lineRendererArc.startWidth = annotationWidth * annotationWidthMultiplier;
+        lineRendererArc.endWidth = annotationWidth * annotationWidthMultiplier;
         lineRendererArc.material = annotationMaterial;
 
         lineRendererArc.positionCount = pointCount;

--- a/Assets/Scripts/AnnotationTool.cs
+++ b/Assets/Scripts/AnnotationTool.cs
@@ -55,7 +55,7 @@ public class AnnotationTool : MonoBehaviour
                 // stretch most recent annotation to the end point
                 endPointForDrawing = nextPoint;
 
-                AddAnnotationLineRenderer(startPointForDrawing, endPointForDrawing, SimulationManager.Instance.LocalPlayerColor);
+                AddAnnotationLineRenderer(currentAnnotation, startPointForDrawing, endPointForDrawing, SimulationManager.Instance.LocalPlayerColor);
 
                 currentAnnotation.GetComponent<AnnotationLine>().FinishDrawing();
 
@@ -76,18 +76,18 @@ public class AnnotationTool : MonoBehaviour
         }
     }
 
-    private void AddAnnotationLineRenderer(Vector3 startPos, Vector3 endPos, Color playerColor)
+    private void AddAnnotationLineRenderer(GameObject _currentAnnotation, Vector3 startPos, Vector3 endPos, Color playerColor)
     {
-        currentAnnotation.GetComponent<AnnotationLine>().StartPos = startPos;
-        currentAnnotation.GetComponent<AnnotationLine>().EndPos = endPos;
-        currentAnnotation.GetComponent<AnnotationLine>().RemoveStartPoint();
+        _currentAnnotation.GetComponent<AnnotationLine>().StartPos = startPos;
+        _currentAnnotation.GetComponent<AnnotationLine>().EndPos = endPos;
+        _currentAnnotation.GetComponent<AnnotationLine>().RemoveStartPoint();
 
         int pointCount = 30;
 
-        currentAnnotation.layer = LayerMask.NameToLayer("Marker");
+        _currentAnnotation.layer = LayerMask.NameToLayer("Marker");
 
-        LineRenderer lineRendererArc = currentAnnotation.AddComponent<LineRenderer>();
-        MeshCollider meshColliderArc = currentAnnotation.AddComponent<MeshCollider>();
+        LineRenderer lineRendererArc = _currentAnnotation.AddComponent<LineRenderer>();
+        MeshCollider meshColliderArc = _currentAnnotation.AddComponent<MeshCollider>();
         Mesh mesh = new Mesh();
         lineRendererArc.useWorldSpace = false;
         lineRendererArc.startWidth = annotationWidth * 2f;
@@ -148,9 +148,9 @@ public class AnnotationTool : MonoBehaviour
 
     private void addAnnotation(Vector3 startPos, Vector3 endPos, string annotationName, Color playerColor)
     {
-        GameObject currentAnnotation = Instantiate(annotationLinePrefab, new Vector3(0, 0, 0), Quaternion.identity, this.transform);
-        currentAnnotation.name = annotationName;
-        AddAnnotationLineRenderer(startPos, endPos, playerColor);
+        GameObject newAnnotation = Instantiate(annotationLinePrefab, new Vector3(0, 0, 0), Quaternion.identity, this.transform);
+        newAnnotation.name = annotationName;
+        AddAnnotationLineRenderer(newAnnotation, startPos, endPos, playerColor);
     }
 
     void DeleteAnnotation(string annotationName)

--- a/Assets/Scripts/Core/SimulationEvents.cs
+++ b/Assets/Scripts/Core/SimulationEvents.cs
@@ -7,7 +7,7 @@ public class LocationSelectedEvent : UnityEvent<string> { }
 // [System.Serializable]
 // public class LocationChangeEvent : UnityEvent<LatLng, string> { }
 // [System.Serializable]
-public class AnnotationAddedEvent : UnityEvent<Vector3, Quaternion, Vector3, string> { }
+public class AnnotationAddedEvent : UnityEvent<Vector3, Vector3, string> { }
 [System.Serializable]
 public class AnnotationDeletedEvent : UnityEvent<string> { }
 [System.Serializable]

--- a/Assets/Scripts/Network/NetworkController.cs
+++ b/Assets/Scripts/Network/NetworkController.cs
@@ -130,7 +130,7 @@ public class NetworkController : MonoBehaviour
     {
         /*
          * Get Colyseus endpoint from InputField
-         *  for localhost use ws://localhost:2567/        
+         *  for localhost use ws://localhost:2567/
          */
         if (!IsConnected)
         {
@@ -398,10 +398,10 @@ public class NetworkController : MonoBehaviour
         colyseusClient.SendNetworkTransformUpdate(pos, rot, Vector3.one, "", NetworkMessageType.Movement);
     }
 
-    public void BroadcastAnnotation(Vector3 pos, Quaternion rot, Vector3 scale, string annotationName)
+    public void BroadcastAnnotation(Vector3 startPos, Vector3 endPos, string annotationName)
     {
-        CCDebug.Log("Broadcasting new Annotation event " + pos, LogLevel.Verbose, LogMessageCategory.Networking);
-        colyseusClient.SendNetworkTransformUpdate(pos, rot, scale, annotationName, NetworkMessageType.Annotation);
+        CCDebug.Log("Broadcasting new Annotation event " + startPos + endPos, LogLevel.Verbose, LogMessageCategory.Networking);
+        colyseusClient.SendNetworkAnnotationUpdate(startPos, endPos, annotationName, NetworkMessageType.Annotation);
     }
     public void BroadcastDeleteAnnotation(string annotationName)
     {

--- a/Assets/Scripts/SimulationManagerComponent.cs
+++ b/Assets/Scripts/SimulationManagerComponent.cs
@@ -53,6 +53,8 @@ public class SimulationManagerComponent : MonoBehaviour
     float markerLineWidth = .1f;
     [SerializeField]
     float markerScale = 1f;
+    [SerializeField]
+    float annotationWidthMultiplier = 1f;
 
     // Settings for constellations
     [SerializeField]
@@ -163,6 +165,7 @@ public class SimulationManagerComponent : MonoBehaviour
 
             AnnotationTool annotationTool = FindObjectOfType<AnnotationTool>();
             annotationTool.Init();
+            annotationTool.annotationWidthMultiplier = annotationWidthMultiplier;
 
             manager.DataControllerComponent.UpdateOnSceneLoad();
         }
@@ -184,6 +187,8 @@ public class SimulationManagerComponent : MonoBehaviour
             {
                 manager.ConstellationsControllerComponent.SetSceneParameters(lineWidth, showConstellationConnections);
             }
+            AnnotationTool annotationTool = FindObjectOfType<AnnotationTool>();
+            annotationTool.annotationWidthMultiplier = annotationWidthMultiplier;
         }
         if (!manager.MainMenu)
         {

--- a/Assets/Scripts/Utilities/CCLogger.cs
+++ b/Assets/Scripts/Utilities/CCLogger.cs
@@ -192,9 +192,9 @@ public class CCLogger
     }
 
     // localPosition, localRotation, localScale, name
-    private void AnnotationAdded(Vector3 position, Quaternion rotation, Vector3 scale, string name)
+    private void AnnotationAdded(Vector3 startPos, Vector3 endPos, string name)
     {
-        string msg = $"Name:{name}, P:{position.ToString()}, R:{rotation.ToString()}, S:{scale.ToString()}";
+        string msg = $"Name:{name}, StartP:{startPos.ToString()}, EndP:{endPos.ToString()}";
         _logAsync(LOG_EVENT_ANNOTATION_ADDED, msg);
     }
 
@@ -290,7 +290,6 @@ public class CCLogger
     private void ConstellationSelected(string constellation) {
         _logAsync(LOG_EVENT_CONSTELLATION_SELECTED, constellation);
     }
-
 
     #endregion Event Dispatching:
     /********************* END EVENT DISPATCHING SECTION ********************/


### PR DESCRIPTION
This PR updates the annotation lines to use curved line renderers that follow the path of the celestial sphere rather than using a straight line that is scaled from the center point (which causes a "toothpick" effect when viewed in the star scene.  A slerp function is used to create 30 line segments along the arc of the celestial sphere given a start point and an end point defined by the user.
 
Note: network communication will ideally be cleaned up when more development time opens up.  Ideally we want a new network type/class for passing annotation information, but the current code gets the job done for now.

Note2: additional features to set a line width multiplier and scale the annotation tool game object are in place to facilitate changes needed for the HoloLens version.

![curved-lines](https://user-images.githubusercontent.com/5126913/130580328-6dbb19f2-adef-46a9-af2a-3980d1617609.gif)
