### PR TITLE
2022-01-25 - Use SSL for Websocket & Log Server connections

### DIFF
--- a/Assets/Scripts/Network/ServerList.cs
+++ b/Assets/Scripts/Network/ServerList.cs
@@ -21,8 +21,8 @@ public class ServerList
 
     public static ServerRecord Local = new ServerRecord("Local", "ws://localhost:2567");
     public static ServerRecord Custom = new ServerRecord("Custom", "ws://192.168.1.86:2567");
-    public static ServerRecord Dev = new ServerRecord("Dev", "ws://ceasar-serve-update-col-4va3ac.herokuapp.com/");
-    public static ServerRecord Web = new ServerRecord("Web", "ws://ceasar-server-staging.herokuapp.com/");
+    public static ServerRecord Dev = new ServerRecord("Dev", "wss://ceasar-serve-update-col-4va3ac.herokuapp.com/");
+    public static ServerRecord Web = new ServerRecord("Web", "wss://ceasar-server-staging.herokuapp.com/");
 
     // track our single instance:
     private static ServerList instance;

--- a/Assets/Scripts/Utilities/SimulationConstants.cs
+++ b/Assets/Scripts/Utilities/SimulationConstants.cs
@@ -93,7 +93,7 @@ public static class SimulationConstants
     public static readonly string CONSTELLATIONS_NONE = "none";
 
     // ======== Logging configuration: ====================================================
-    public static readonly string LOG_URL = "http://cc-log-manager.herokuapp.com/api/logs";
+    public static readonly string LOG_URL = "https://cc-log-manager.herokuapp.com/api/logs";
     public static readonly string LOG_APP_NAME = "CEASAR";
 
     public static readonly string LOG_EVENT_DISCONNECT = "Disconnected";


### PR DESCRIPTION
### Use SSL for Websocket & Log Server connections

Otherwise we get mixed-content security warnings when the application loads over HTTP.