### PR TITLE
Adjust text size in floating panel to fit content (179381008)

### DIFF
--- a/Assets/Prefabs/UI/FloatingInfoPanel.prefab
+++ b/Assets/Prefabs/UI/FloatingInfoPanel.prefab
@@ -130,6 +130,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InfoText: {fileID: 1256842248491330994}
+  playerName: 
+  playerColor: {r: 0, g: 0, b: 0, a: 0}
 --- !u!65 &6501324817522418085
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -284,9 +286,9 @@ MonoBehaviour:
   m_fontSize: 20
   m_fontSizeBase: 20
   m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 16
+  m_fontSizeMax: 20
   m_fontStyle: 0
   m_HorizontalAlignment: 1
   m_VerticalAlignment: 256


### PR DESCRIPTION
This is a small PR that updates the star panel prefab so that the text box text size will shrink to accommodate large strings (using the autoSizing property).  This prevents text from overflowing off of the star panel.

PT Story:
https://www.pivotaltracker.com/story/show/179381008