### PR TITLE
Add rotation to annotation network communication to sync annotation positions (179381096)

### DIFF
--- a/Assets/Scripts/AnnotationTool.cs
+++ b/Assets/Scripts/AnnotationTool.cs
@@ -141,7 +141,7 @@ public class AnnotationTool : MonoBehaviour
     {
         // This is a hack to use the NetworkTransform class to communicate the start/end positions
         // of the annotation. The NetworkTransform class is designed to store center, scale, and rotation,
-        // but for now we will store the start and end positions of the annotation in the first and third vector3 slots.
+        // but for now we will store the start and end positions of the annotation in the position and localScale vector3 slots.
         // Ideally we will clean this up and expand the network communication structures to handle the
         // annotations properly.
         Vector3 startPos = Utils.NetworkV3ToVector3(lastAnnotation.position);

--- a/Assets/Scripts/Core/SimulationEvents.cs
+++ b/Assets/Scripts/Core/SimulationEvents.cs
@@ -7,7 +7,7 @@ public class LocationSelectedEvent : UnityEvent<string> { }
 // [System.Serializable]
 // public class LocationChangeEvent : UnityEvent<LatLng, string> { }
 // [System.Serializable]
-public class AnnotationAddedEvent : UnityEvent<Vector3, Vector3, string> { }
+public class AnnotationAddedEvent : UnityEvent<Vector3, Vector3, Vector3, string> { }
 [System.Serializable]
 public class AnnotationDeletedEvent : UnityEvent<string> { }
 [System.Serializable]

--- a/Assets/Scripts/Network/ColyseusClient.cs
+++ b/Assets/Scripts/Network/ColyseusClient.cs
@@ -238,7 +238,7 @@ public class ColyseusClient : MonoBehaviour
             NetworkTransform t = new NetworkTransform();
             // This is a hack to use the NetworkTransform class to communicate the start/end positions
             // of the annotation. The NetworkTransform class is designed to store center, scale, and rotation,
-            // but for now we will store the start and end positions of the annotation in the first and third vector3 slots.
+            // but for now we will store the start and end positions of the annotation in the position and localScale vector3 slots.
             // Ideally we will clean this up and expand the network communication structures to handle the
             // annotations properly.
             t.position = new NetworkVector3 { x = startPos.x, y = startPos.y, z = startPos.z };

--- a/Assets/Scripts/Network/ColyseusClient.cs
+++ b/Assets/Scripts/Network/ColyseusClient.cs
@@ -231,19 +231,19 @@ public class ColyseusClient : MonoBehaviour
         }
     }
 
-    public async void SendNetworkAnnotationUpdate(Vector3 startPos, Vector3 endPos, string transformName, NetworkMessageType messageType)
+    public async void SendNetworkAnnotationUpdate(Vector3 startPos, Vector3 endPos, Vector3 rotation, string transformName, NetworkMessageType messageType)
     {
         if (IsConnected)
         {
             NetworkTransform t = new NetworkTransform();
             // This is a hack to use the NetworkTransform class to communicate the start/end positions
             // of the annotation. The NetworkTransform class is designed to store center, scale, and rotation,
-            // but for now we will store the start and end positions of the annotation in the first two vector3 slots.
+            // but for now we will store the start and end positions of the annotation in the first and third vector3 slots.
             // Ideally we will clean this up and expand the network communication structures to handle the
             // annotations properly.
             t.position = new NetworkVector3 { x = startPos.x, y = startPos.y, z = startPos.z };
-            t.rotation = new NetworkVector3 { x = endPos.x, y = endPos.y, z = endPos.z };
-            t.localScale = new NetworkVector3 {x = 0, y = 0, z = 0};
+            t.rotation = new NetworkVector3 { x = rotation.x, y = rotation.y, z = rotation.z };
+            t.localScale = new NetworkVector3 { x = endPos.x, y = endPos.y, z = endPos.z };
             t.name = transformName;
             await room.Send(messageType.ToString(), t);
         }

--- a/Assets/Scripts/Network/NetworkController.cs
+++ b/Assets/Scripts/Network/NetworkController.cs
@@ -398,10 +398,10 @@ public class NetworkController : MonoBehaviour
         colyseusClient.SendNetworkTransformUpdate(pos, rot, Vector3.one, "", NetworkMessageType.Movement);
     }
 
-    public void BroadcastAnnotation(Vector3 startPos, Vector3 endPos, string annotationName)
+    public void BroadcastAnnotation(Vector3 startPos, Vector3 endPos, Vector3 rotation, string annotationName)
     {
         CCDebug.Log("Broadcasting new Annotation event " + startPos + endPos, LogLevel.Verbose, LogMessageCategory.Networking);
-        colyseusClient.SendNetworkAnnotationUpdate(startPos, endPos, annotationName, NetworkMessageType.Annotation);
+        colyseusClient.SendNetworkAnnotationUpdate(startPos, endPos, rotation, annotationName, NetworkMessageType.Annotation);
     }
     public void BroadcastDeleteAnnotation(string annotationName)
     {

--- a/Assets/Scripts/Utilities/CCLogger.cs
+++ b/Assets/Scripts/Utilities/CCLogger.cs
@@ -192,9 +192,9 @@ public class CCLogger
     }
 
     // localPosition, localRotation, localScale, name
-    private void AnnotationAdded(Vector3 startPos, Vector3 endPos, string name)
+    private void AnnotationAdded(Vector3 startPos, Vector3 endPos, Vector3 rotation, string name)
     {
-        string msg = $"Name:{name}, StartP:{startPos.ToString()}, EndP:{endPos.ToString()}";
+        string msg = $"Name:{name}, StartP:{startPos.ToString()}, EndP:{endPos.ToString()} Rot:{rotation.ToString()}";
         _logAsync(LOG_EVENT_ANNOTATION_ADDED, msg);
     }
 


### PR DESCRIPTION
This PR makes improvements to the network communication of annotations so that annotations are correctly placed regardless of the user's current time and location.  This is done by passing an additional rotation value that is used to compute annotation positions.

NOTE: to do this properly we will likely want to change the network at some point to support a new annotation type where we can send start position, end position, and rotation.  At present I'm using an existing network type, `NetworkTransform`, that works but isn't designed for the annotation data.  In both cases we need to send 3 Vector3 objects, but the `NetworkTransform` and `NetworkAnnotation` (a proposed new type) will need different naming conventions for properties.  I'm voting that we put this off until we have time to make a pass and update the network (which will be needed when we get the network communication of the North Pin story).

PT Story:
https://www.pivotaltracker.com/story/show/179381096


![annotate](https://user-images.githubusercontent.com/5126913/151633210-f690c56a-600a-4ea0-bc54-d8c9e662074d.gif)

